### PR TITLE
Additional options in SuperaSpacePoint and SuperaTrue2RecoVoxel3D

### DIFF
--- a/SuperaBBoxInteraction.cxx
+++ b/SuperaBBoxInteraction.cxx
@@ -36,7 +36,7 @@ namespace larcv {
 
     _use_fixed_bbox = cfg.get<bool>("UseFixedBBox", false);
     _bbox_bottom = cfg.get<std::vector<double>>("BBoxBottom", {0, 0, 0});
-    assert(_box_start_at.size() == 3);
+    assert(_bbox_bottom.size() == 3);
     
     auto tpc_v = cfg.get<std::vector<unsigned short> >("TPCList");
     larcv::Point3D min_pt(1.e9,1.e9,1.e9);

--- a/SuperaSpacePoint.h
+++ b/SuperaSpacePoint.h
@@ -50,6 +50,7 @@ namespace larcv {
     size_t _max_debug_dropping = 0; // Max debug message for dropping space points
     unsigned short _n_planes = 3;
     bool _store_wire_info = false;
+    std::unordered_set<std::string> _drop_output;
   };
 
   /**
@@ -61,8 +62,6 @@ namespace larcv {
     /// ctor
     SuperaSpacePointProcessFactory() { 
         ProcessFactory::get().add_factory("SuperaSpacePoint", this);
-        std::cout << "[Patrick] Added SuperaSpacePoint to ProcessFactory"
-            << std::endl;
     }
     /// dtor
     ~SuperaSpacePointProcessFactory() {}

--- a/SuperaTrue2RecoVoxel3D.cxx
+++ b/SuperaTrue2RecoVoxel3D.cxx
@@ -177,6 +177,8 @@ namespace larcv {
     _dump_to_csv = cfg.get<bool>("DumpToCSV", false);
     _post_averaging = cfg.get<bool>("PostAveraging", false);
     _post_averaging_threshold = cfg.get<double>("PostAveragingThreshold_cm", 0.3);
+    _reco_charge_range = cfg.get<std::vector<double>>("RecoChargeRange", {0,9e99}); 
+    assert(_reco_charge_range.size() == 2);
   }
 
 
@@ -311,8 +313,17 @@ namespace larcv {
     if (!space_pts.isValid()) return true;
     art::FindManyP<recob::Hit> hit_finder(space_pts, *ev, _sps_producer);
 
+    size_t n_dropped = 0;
     for (size_t i = 0; i < space_pts->size(); ++i) {
       auto const &pt = space_pts->at(i);
+
+      // put a charge threshold on reco pt
+      double reco_charge = pt.ErrXYZ()[1];
+      if (reco_charge < _reco_charge_range[0] || reco_charge > _reco_charge_range[1]) {
+        ++n_dropped;
+        continue;
+      }
+
       auto *xyz = pt.XYZ();
 
       auto reco_voxel_id = meta3d.id(xyz[0], xyz[1], xyz[2]);
@@ -388,6 +399,11 @@ namespace larcv {
       for (auto const& true_pt: overlaps)
         insert_one_to_many(_true2reco, true_pt, reco_voxel3d);
     } // end looping reco pts
+
+    LARCV_INFO()
+      << "Dropping " << n_dropped 
+      << " out of " << space_pts->size()
+      << " reco pts" << std::endl;
 
     // debug in csv file
     auto save_to = [&](std::string prefix) {

--- a/SuperaTrue2RecoVoxel3D.h
+++ b/SuperaTrue2RecoVoxel3D.h
@@ -71,6 +71,8 @@ namespace larcv {
     double _hit_threshold_ne;
     double _hit_window_ticks;
 
+    std::vector<double> _reco_charge_range;
+
     // Map (true_id, track_id) -> [RecoVoxel3D]
     std::map<TrackVoxel_t, std::unordered_set<RecoVoxel3D>> _true2reco;
     


### PR DESCRIPTION
__Drop output in SuperaSpacePoint__
```
SuperaSpacePoint: {
...
DropOutput: []
...
}
```
- `DropOutput: ["hit_*"]`  - remove ALL wire info
- `DropOutput: ["hit_charge"]`  - remove `hit_charge{0,1,2}`
- `DropOutput: ["hit_charge0","hit_time1","hit_charge_asym"]` -  remove individual product
Default: _None_
-----
__Apply Reco Charge Threshold in SuperaTrue2RecoVoxel3D__
```
SuperaTrue2RecoVoxel3D: {
...
RecoChargeRange: [-1000,40000]
}
```
Default: `[0,9e99]`