### PR TITLE
PMT/CRT information storage + SEDLite 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 CMakeLists.txt
 !experiments/*/CMakeLists.txt
 FMWKInterface.*
+ExperimentTypes.*
 *.txt
 *.bin
 *.root

--- a/FMWKInterface.h
+++ b/FMWKInterface.h
@@ -17,6 +17,7 @@
 #include "lardataobj/MCBase/MCTrack.h"
 #include "lardataobj/Simulation/SimChannel.h"
 #include "lardataobj/Simulation/SimEnergyDeposit.h"
+#include "lardataobj/Simulation/SimEnergyDepositLite.h"
 #include "larcore/CoreUtils/ServiceUtil.h"
 
 namespace supera {
@@ -31,6 +32,7 @@ namespace supera {
   typedef sim::SimChannel    LArSimCh_t;
   typedef sim::MCStep        LArMCStep_t;
   typedef sim::SimEnergyDeposit LArSimEnergyDeposit_t;
+  typedef sim::SimEnergyDepositLite LArSimEnergyDepositLite_t;
   typedef recob::SpacePoint  LArSpacePoint_t;
 	typedef recob::OpFlash     LArOpFlash_t;
 }

--- a/FMWKInterface.h
+++ b/FMWKInterface.h
@@ -8,6 +8,8 @@
 #include "larcv/core/DataFormat/DataFormatTypes.h"
 #include "nusimdata/SimulationBase/MCTruth.h"
 #include "nusimdata/SimulationBase/MCParticle.h"
+//#include "lardataobj/MCBase/MCMiniPart.h"
+#include "lardataobj/MCBase/MCParticleLite.h"
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/OpFlash.h"
 #include "lardataobj/RecoBase/Wire.h"
@@ -28,6 +30,7 @@ namespace supera {
   typedef recob::Hit         LArHit_t;
   typedef simb::MCTruth      LArMCTruth_t;
   typedef simb::MCParticle   LArMCParticle_t;
+  typedef sim::MCParticleLite  LArMCMiniPart_t;
   typedef sim::MCTrack       LArMCTrack_t;
   typedef sim::MCShower      LArMCShower_t;
   typedef sim::SimChannel    LArSimCh_t;

--- a/FMWKInterface.h
+++ b/FMWKInterface.h
@@ -19,6 +19,7 @@
 #include "lardataobj/Simulation/SimEnergyDeposit.h"
 #include "lardataobj/Simulation/SimEnergyDepositLite.h"
 #include "larcore/CoreUtils/ServiceUtil.h"
+#include "ExperimentTypes.h"
 
 namespace supera {
   typedef larcv::PSet        Config_t;

--- a/LArSoftSuperaDriver_module.cc
+++ b/LArSoftSuperaDriver_module.cc
@@ -171,6 +171,10 @@ void LArSoftSuperaDriver::analyze(art::Event const & e)
   // mcparticle
   if(_verbosity==0) std::cout << "Checking MCParticle data request" << std::endl;
   get_label<simb::MCParticle>(e, ::supera::LArDataType_t::kLArMCParticle_t, true);
+
+  // mcminipart
+  if(_verbosity==0) std::cout << "Checking MCMiniPart data request" << std::endl;
+  get_label<sim::MCParticleLite>(e, ::supera::LArDataType_t::kLArMCMiniPart_t, true);
   //
   // SimEnergyDeposit
   if(_verbosity==0) std::cout << "Checking SimEnergyDeposit data request" << std::endl;

--- a/LArSoftSuperaDriver_module.cc
+++ b/LArSoftSuperaDriver_module.cc
@@ -61,7 +61,7 @@ public:
   void beginJob() override;
   void endJob() override;
 
-	template<typename LArSoftDataType> void get_label(const art::Event& e, ::supera::LArDataType_t SuperaDataType, bool checkLength = false);
+	template<class LArSoftDataType> void get_label(const art::Event& e, ::supera::LArDataType_t SuperaDataType, bool checkLength = false);
 
 private:
 

--- a/SuperaBBoxInteraction.h
+++ b/SuperaBBoxInteraction.h
@@ -38,12 +38,15 @@ namespace larcv {
 
     void initialize();
 
+		template <class T> void AdaptBBoxToSED(std::vector<T> const& sedep_v, larcv::BBox3D& bbox);
+
     bool process(IOManager& mgr);
 
     void finalize();
 
   private:
 
+		bool _use_sed_lite; ///< whether to use sim::SimEnergyDeposit or sim::SimEnergyDepositLite
     unsigned short _origin;
     double _xlen, _ylen, _zlen;
     double _xvox, _yvox, _zvox;

--- a/SuperaBase.cxx
+++ b/SuperaBase.cxx
@@ -37,6 +37,8 @@ namespace larcv {
     auto producer_simedep  = cfg.get<std::string>("LArSimEnergyDepositProducer", "");
     auto producer_simedep_lite  = cfg.get<std::string>("LArSimEnergyDepositLiteProducer", "");
     auto producer_sps      = cfg.get<std::string>("LArSpacePoint",         "");
+    auto producer_opflash  = cfg.get<std::string>("LArOpFlashProducer",         "");
+    auto producer_crthit   = cfg.get<std::string>("LArCRTHitProducer",         "");
 
     if(!producer_wire.empty()    ) {
       LARCV_INFO() << "Requesting Wire data product by " << producer_wire << std::endl;
@@ -92,6 +94,16 @@ namespace larcv {
       LARCV_INFO() << "Requesting SpacePoint data product by " << producer_sps << std::endl;
       Request(supera::LArDataType_t::kLArSpacePoint_t, producer_sps);
     }
+
+    if(!producer_opflash.empty() ) {
+      LARCV_INFO() << "Requesting Opflash data product by " << producer_opflash << std::endl;
+      Request(supera::LArDataType_t::kLArOpFlash_t, producer_opflash);
+    }
+
+    if(!producer_crthit.empty() ) {
+      LARCV_INFO() << "Requesting CRTHit data product by " << producer_crthit << std::endl;
+      Request(supera::LArDataType_t::kLArCRTHit_t, producer_crthit);
+    }
   }
 
   void SuperaBase::initialize()
@@ -121,6 +133,8 @@ namespace larcv {
     _ptr_mcs_v      = nullptr;
     _ptr_simedep_v  = nullptr;
     _ptr_simedep_lite_v  = nullptr;
+    _ptr_opflash_v  = nullptr;
+    _ptr_crthit_v   = nullptr;
 
     // FIXME(kvtsang) Temporary solution to access associations
     _event          = nullptr;
@@ -166,6 +180,12 @@ namespace larcv {
   template <> const std::vector<supera::LArSpacePoint_t>& SuperaBase::LArData<supera::LArSpacePoint_t>() const
   { if(!_ptr_spacepoint_v) throw larbys("SpacePoint data pointer not available"); return *_ptr_spacepoint_v; }
 
+  template <> const std::vector<supera::LArOpFlash_t>& SuperaBase::LArData<supera::LArOpFlash_t>() const
+  { if(!_ptr_opflash_v) throw larbys("OpFlash data pointer not available"); return *_ptr_opflash_v; }
+
+  template <> const std::vector<supera::LArCRTHit_t>& SuperaBase::LArData<supera::LArCRTHit_t>() const
+  { if(!_ptr_crthit_v) throw larbys("CRTHit data pointer not available"); return *_ptr_crthit_v; }
+
   template <> void SuperaBase::LArData(const std::vector<supera::LArWire_t>& data_v)
   { _ptr_wire_v = (std::vector<supera::LArWire_t>*)(&data_v); }
 
@@ -199,6 +219,11 @@ namespace larcv {
   template <> void SuperaBase::LArData(const std::vector<supera::LArSpacePoint_t>& data_v)
   { _ptr_spacepoint_v = (std::vector<supera::LArSpacePoint_t>*)(&data_v); }
 
+  template <> void SuperaBase::LArData(const std::vector<supera::LArOpFlash_t>& data_v)
+  { _ptr_opflash_v = (std::vector<supera::LArOpFlash_t>*)(&data_v); }
+
+  template <> void SuperaBase::LArData(const std::vector<supera::LArCRTHit_t>& data_v)
+  { _ptr_crthit_v = (std::vector<supera::LArCRTHit_t>*)(&data_v); }
 }
 
 #endif

--- a/SuperaBase.cxx
+++ b/SuperaBase.cxx
@@ -21,11 +21,11 @@ namespace larcv {
     if(iter == _data_request_m.end()) return _empty_string;
     return (*iter).second;
   }
-  
+
   void SuperaBase::configure(const PSet& cfg)
   {
     _time_offset  = cfg.get<int>("TimeOffset",2400);
-    
+
     auto producer_wire     = cfg.get<std::string>("LArWireProducer",       "");
     auto producer_hit      = cfg.get<std::string>("LArHitProducer",        "");
     auto producer_opdigit  = cfg.get<std::string>("LArOpDigitProducer",    "");
@@ -35,6 +35,7 @@ namespace larcv {
     auto producer_mcshower = cfg.get<std::string>("LArMCShowerProducer",   "");
     auto producer_simch    = cfg.get<std::string>("LArSimChProducer",      "");
     auto producer_simedep  = cfg.get<std::string>("LArSimEnergyDepositProducer", "");
+    auto producer_simedep_lite  = cfg.get<std::string>("LArSimEnergyDepositLiteProducer", "");
     auto producer_sps      = cfg.get<std::string>("LArSpacePoint",         "");
 
     if(!producer_wire.empty()    ) {
@@ -46,7 +47,7 @@ namespace larcv {
       LARCV_INFO() << "Requesting Hit data product by " << producer_hit << std::endl;
       Request(supera::LArDataType_t::kLArHit_t, producer_hit);
     }
-    
+
     if(!producer_opdigit.empty() ) {
       LARCV_INFO() << "Requesting OpDigit data product by " << producer_opdigit << std::endl;
       Request(supera::LArDataType_t::kLArOpDigit_t, producer_opdigit );
@@ -61,17 +62,17 @@ namespace larcv {
       LARCV_INFO() << "Requesting MCParticle data product by " << producer_mcpart << std::endl;
       Request(supera::LArDataType_t::kLArMCParticle_t, producer_mcpart );
     }
-    
+
     if(!producer_mctrack.empty() ) {
       LARCV_INFO() << "Requesting MCTrack data product by " << producer_mctrack << std::endl;
       Request(supera::LArDataType_t::kLArMCTrack_t, producer_mctrack );
     }
-    
+
     if(!producer_mcshower.empty()) {
       LARCV_INFO() << "Requesting MCShower data product by " << producer_mcshower << std::endl;
       Request(supera::LArDataType_t::kLArMCShower_t, producer_mcshower);
     }
-    
+
     if(!producer_simch.empty()   ) {
       LARCV_INFO() << "Requesting SimCh data product by " << producer_simch << std::endl;
       Request(supera::LArDataType_t::kLArSimCh_t, producer_simch);
@@ -80,6 +81,11 @@ namespace larcv {
     if(!producer_simedep.empty()   ) {
       LARCV_INFO() << "Requesting SimEnergyDeposit data product by " << producer_simedep << std::endl;
       Request(supera::LArDataType_t::kLArSimEnergyDeposit_t, producer_simedep);
+    }
+
+    if(!producer_simedep_lite.empty()   ) {
+      LARCV_INFO() << "Requesting SimEnergyDepositLite data product by " << producer_simedep_lite << std::endl;
+      Request(supera::LArDataType_t::kLArSimEnergyDepositLite_t, producer_simedep_lite);
     }
 
     if(!producer_sps.empty() ) {
@@ -114,6 +120,7 @@ namespace larcv {
     _ptr_mct_v      = nullptr;
     _ptr_mcs_v      = nullptr;
     _ptr_simedep_v  = nullptr;
+    _ptr_simedep_lite_v  = nullptr;
 
     // FIXME(kvtsang) Temporary solution to access associations
     _event          = nullptr;
@@ -153,6 +160,9 @@ namespace larcv {
   template <> const std::vector<supera::LArSimEnergyDeposit_t>& SuperaBase::LArData<supera::LArSimEnergyDeposit_t>() const
   { if(!_ptr_simedep_v) throw larbys("SimEnergyDeposit data pointer not available"); return *_ptr_simedep_v; }
 
+  template <> const std::vector<supera::LArSimEnergyDepositLite_t>& SuperaBase::LArData<supera::LArSimEnergyDepositLite_t>() const
+  { if(!_ptr_simedep_lite_v) throw larbys("SimEnergyDepositLite data pointer not available"); return *_ptr_simedep_lite_v; }
+
   template <> const std::vector<supera::LArSpacePoint_t>& SuperaBase::LArData<supera::LArSpacePoint_t>() const
   { if(!_ptr_spacepoint_v) throw larbys("SpacePoint data pointer not available"); return *_ptr_spacepoint_v; }
 
@@ -182,7 +192,10 @@ namespace larcv {
 
   template <> void SuperaBase::LArData(const std::vector<supera::LArSimEnergyDeposit_t>& data_v)
   { _ptr_simedep_v = (std::vector<supera::LArSimEnergyDeposit_t>*)(&data_v); }
-  
+
+  template <> void SuperaBase::LArData(const std::vector<supera::LArSimEnergyDepositLite_t>& data_v)
+  { _ptr_simedep_lite_v = (std::vector<supera::LArSimEnergyDepositLite_t>*)(&data_v); }
+
   template <> void SuperaBase::LArData(const std::vector<supera::LArSpacePoint_t>& data_v)
   { _ptr_spacepoint_v = (std::vector<supera::LArSpacePoint_t>*)(&data_v); }
 

--- a/SuperaBase.h
+++ b/SuperaBase.h
@@ -91,6 +91,7 @@ namespace larcv {
     std::vector<supera::LArSimCh_t>*      _ptr_sch_v;
     std::vector<supera::LArMCTruth_t>*    _ptr_mctruth_v;
     std::vector<supera::LArMCParticle_t>* _ptr_mcp_v;
+    std::vector<supera::LArMCMiniPart_t>* _ptr_mcmp_v;
     std::vector<supera::LArMCTrack_t>*    _ptr_mct_v;
     std::vector<supera::LArMCShower_t>*   _ptr_mcs_v;
     std::vector<supera::LArSimEnergyDeposit_t>* _ptr_simedep_v;
@@ -99,6 +100,7 @@ namespace larcv {
     std::vector<supera::LArOpFlash_t>*    _ptr_opflash_v;
     std::vector<supera::LArCRTHit_t>*     _ptr_crthit_v;
     std::string _csv_fname;
+    bool        _combined_mcmp;
 
     // FIXME(kvtsang) Temporary solution to access associations
     const art::Event *_event;
@@ -143,6 +145,8 @@ namespace larcv {
   template <> void SuperaBase::LArData(const std::vector<supera::LArMCTruth_t>& data_v);
 
   template <> void SuperaBase::LArData(const std::vector<supera::LArMCParticle_t>& data_v);
+
+  template <> void SuperaBase::LArData(const std::vector<supera::LArMCMiniPart_t>& data_v);
 
   template <> void SuperaBase::LArData(const std::vector<supera::LArMCTrack_t>& data_v);
 

--- a/SuperaBase.h
+++ b/SuperaBase.h
@@ -96,6 +96,8 @@ namespace larcv {
     std::vector<supera::LArSimEnergyDeposit_t>* _ptr_simedep_v;
     std::vector<supera::LArSimEnergyDepositLite_t>* _ptr_simedep_lite_v;
     std::vector<supera::LArSpacePoint_t>* _ptr_spacepoint_v;
+    std::vector<supera::LArOpFlash_t>*    _ptr_opflash_v;
+    std::vector<supera::LArCRTHit_t>*     _ptr_crthit_v;
     std::string _csv_fname;
 
     // FIXME(kvtsang) Temporary solution to access associations
@@ -128,6 +130,10 @@ namespace larcv {
 
   template <> const std::vector<supera::LArSpacePoint_t>& SuperaBase::LArData<supera::LArSpacePoint_t>() const;
 
+  template <> const std::vector<supera::LArOpFlash_t>& SuperaBase::LArData<supera::LArOpFlash_t>() const;
+
+  template <> const std::vector<supera::LArCRTHit_t>& SuperaBase::LArData<supera::LArCRTHit_t>() const;
+
   template <> void SuperaBase::LArData(const std::vector<supera::LArWire_t>& data_v);
 
   template <> void SuperaBase::LArData(const std::vector<supera::LArHit_t>& data_v);
@@ -150,6 +156,9 @@ namespace larcv {
 
   template <> void SuperaBase::LArData(const std::vector<supera::LArSpacePoint_t>& data_v);
 
+  template <> void SuperaBase::LArData(const std::vector<supera::LArOpFlash_t>& data_v);
+
+  template <> void SuperaBase::LArData(const std::vector<supera::LArCRTHit_t>& data_v);
   /**
      \class larcv::SuperaBaseFactory
      \brief A concrete factory class for larcv::SuperaBase

--- a/SuperaBase.h
+++ b/SuperaBase.h
@@ -123,6 +123,9 @@ namespace larcv {
   template <> const std::vector<supera::LArMCShower_t>& SuperaBase::LArData<supera::LArMCShower_t>() const;
 
   template <> const std::vector<supera::LArSimEnergyDeposit_t>& SuperaBase::LArData<supera::LArSimEnergyDeposit_t>() const;
+
+  template <> const std::vector<supera::LArSimEnergyDepositLite_t>& SuperaBase::LArData<supera::LArSimEnergyDepositLite_t>() const;
+
   template <> const std::vector<supera::LArSpacePoint_t>& SuperaBase::LArData<supera::LArSpacePoint_t>() const;
 
   template <> void SuperaBase::LArData(const std::vector<supera::LArWire_t>& data_v);
@@ -142,6 +145,8 @@ namespace larcv {
   template <> void SuperaBase::LArData(const std::vector<supera::LArSimCh_t>& data_v);
 
   template <> void SuperaBase::LArData(const std::vector<supera::LArSimEnergyDeposit_t>& data_v);
+
+  template <> void SuperaBase::LArData(const std::vector<supera::LArSimEnergyDepositLite_t>& data_v);
 
   template <> void SuperaBase::LArData(const std::vector<supera::LArSpacePoint_t>& data_v);
 

--- a/SuperaBase.h
+++ b/SuperaBase.h
@@ -2,7 +2,7 @@
  * \file SuperaBase.h
  *
  * \ingroup Package_Name
- * 
+ *
  * \brief Class def header for a class SuperaBase
  *
  * @author kazuhiro
@@ -34,10 +34,10 @@ namespace larcv {
   class SuperaBase : public ProcessBase {
 
   public:
-    
+
     /// Default constructor
     SuperaBase(const std::string name="SuperaBase");
-    
+
     /// Default destructor
     ~SuperaBase(){}
 
@@ -60,7 +60,7 @@ namespace larcv {
     { _csv_fname = fname; }
 
     // FIXME(kvtsang) Temporary solution to access associations
-    void SetEvent(const art::Event *ev) { _event = ev; }; 
+    void SetEvent(const art::Event *ev) { _event = ev; };
 
     void ClearEventData();
 
@@ -94,6 +94,7 @@ namespace larcv {
     std::vector<supera::LArMCTrack_t>*    _ptr_mct_v;
     std::vector<supera::LArMCShower_t>*   _ptr_mcs_v;
     std::vector<supera::LArSimEnergyDeposit_t>* _ptr_simedep_v;
+    std::vector<supera::LArSimEnergyDepositLite_t>* _ptr_simedep_lite_v;
     std::vector<supera::LArSpacePoint_t>* _ptr_spacepoint_v;
     std::string _csv_fname;
 
@@ -163,5 +164,5 @@ namespace larcv {
 }
 
 #endif
-/** @} */ // end of doxygen group 
+/** @} */ // end of doxygen group
 

--- a/SuperaCRT.cxx
+++ b/SuperaCRT.cxx
@@ -1,0 +1,94 @@
+#ifndef __SUPERACRT_CXX__
+#define __SUPERACRT_CXX__
+
+#include "SuperaCRT.h"
+#include "larcv/core/DataFormat/EventCRTHit.h"
+
+namespace larcv {
+
+  static SuperaCRTProcessFactory __global_SuperaCRTProcessFactory__;
+
+  SuperaCRT::SuperaCRT(const std::string name)
+    : SuperaBase(name)
+  {}
+
+  void SuperaCRT::configure(const PSet& cfg)
+  {
+    SuperaBase::configure(cfg);
+		_crthit_producer_label_v = cfg.get<std::vector<std::string>>("CRTHitProducers");
+		_crthit_output_label_v   = cfg.get<std::vector<std::string>>("CRTHitOutputs");
+
+		if (_crthit_producer_label_v.size() != _crthit_output_label_v.size()) {
+			LARCV_CRITICAL() << "Producer and output labels need to be the same size" << std::endl;
+			throw larbys();
+		}
+
+    for (auto const& label : _crthit_producer_label_v)
+      if (!label.empty())
+        Request(supera::LArDataType_t::kLArCRTHit_t, label);
+	}
+
+  void SuperaCRT::initialize()
+  {
+    SuperaBase::initialize();
+  }
+
+  bool SuperaCRT::process(IOManager& mgr)
+  {
+    SuperaBase::process(mgr);
+
+		auto const *ev = GetEvent();
+
+		for (size_t label_idx = 0; label_idx < _crthit_output_label_v.size(); ++label_idx) {
+			std::string _crthit_output_label = _crthit_output_label_v[label_idx];
+			std::string _crthit_producer_label = _crthit_producer_label_v[label_idx];
+
+			auto& crthit_tensor = mgr.get_data<larcv::EventCRTHit>(_crthit_output_label);
+			//auto const& meta = opflash_tensor.meta();
+
+			auto handle = ev->getValidHandle<std::vector<supera::LArCRTHit_t>>(_crthit_producer_label);
+			if (!handle.isValid()) {
+				LARCV_WARNING() << "No valid CRTHit found for label " << _crthit_producer_label << std::endl;
+				return false;
+			}
+
+			auto const & crthits = *handle;
+
+			std::vector<larcv::CRTHit> cset;
+			for (size_t idx = 0; idx < crthits.size(); ++idx) {
+				auto const& crthit = crthits[idx];
+
+				larcv::CRTHit larcv_crthit;
+        larcv_crthit.id(idx);
+        larcv_crthit.feb_id(crthit.feb_id);
+        larcv_crthit.pesmap(crthit.pesmap);
+        larcv_crthit.peshit(crthit.peshit);
+        larcv_crthit.ts0_s(crthit.ts0_s);
+        larcv_crthit.ts0_s_corr(crthit.ts0_s_corr);
+        larcv_crthit.ts0_ns(crthit.ts0_ns);
+        larcv_crthit.ts0_ns_corr(crthit.ts0_ns_corr);
+        larcv_crthit.ts1_ns(crthit.ts1_ns);
+        larcv_crthit.plane(crthit.plane);
+        larcv_crthit.x_pos(crthit.x_pos);
+        larcv_crthit.x_err(crthit.x_err);
+        larcv_crthit.y_pos(crthit.y_pos);
+        larcv_crthit.y_err(crthit.y_err);
+        larcv_crthit.z_pos(crthit.z_pos);
+        larcv_crthit.z_err(crthit.z_err);
+        larcv_crthit.tagger(crthit.tagger);
+
+				cset.push_back(larcv_crthit);
+			}
+
+
+			crthit_tensor.emplace(std::move(cset));
+		}
+		return true;
+
+	}
+
+  void SuperaCRT::finalize()
+  {}
+}
+
+#endif

--- a/SuperaCRT.h
+++ b/SuperaCRT.h
@@ -1,0 +1,67 @@
+/**
+ * \file SuperaCRT.h
+ *
+ * \ingroup Package_Name
+ *
+ * \brief Class def header for a class SuperaCRT
+ *
+ * @author Temigo
+ */
+
+/** \addtogroup Package_Name
+
+    @{*/
+#ifndef __SUPERAOPTICAL_H__
+#define __SUPERAOPTICAL_H__
+#include "SuperaBase.h"
+#include <vector>
+
+namespace larcv {
+
+  /**
+     \class ProcessBase
+     User defined class SuperaCRT ... these comments are used to generate
+     doxygen documentation!
+  */
+  class SuperaCRT : public SuperaBase {
+
+	public:
+		/// Default constructor
+		SuperaCRT(const std::string name = "SuperaCRT");
+
+		/// Default destructor
+		~SuperaCRT() {}
+
+    void configure(const PSet&);
+
+    void initialize();
+
+    bool process(IOManager& mgr);
+
+    void finalize();
+
+	private:
+		std::vector<std::string> _crthit_producer_label_v;
+		std::vector<std::string> _crthit_output_label_v;
+
+	};
+
+  /**
+     \class larcv::SuperaCRTFactory
+     \brief A concrete factory class for larcv::SuperaCRT
+  */
+  class SuperaCRTProcessFactory : public ProcessFactoryBase {
+  public:
+    /// ctor
+    SuperaCRTProcessFactory() {
+        ProcessFactory::get().add_factory("SuperaCRT", this);
+    }
+    /// dtor
+    ~SuperaCRTProcessFactory() {}
+    /// creation method
+    ProcessBase* create(const std::string instance_name) { return new SuperaCRT(instance_name); }
+  };
+
+}
+
+#endif

--- a/SuperaMCParticleCluster.cxx
+++ b/SuperaMCParticleCluster.cxx
@@ -47,7 +47,7 @@ namespace larcv {
 
 		// If we want to use SED, we have the option
 		// to use SEDLite.
-		_use_sed = cfg.get<bool>("UseSimEnergyDeposit");
+		_use_sed = cfg.get<bool>("UseSimEnergyDeposit", true);
     _use_sed_lite = cfg.get<bool>("UseSimEnergyDepositLite", false);
 
     _use_sed_points = cfg.get<bool>("UseSimEnergyDepositPoints");

--- a/SuperaMCParticleCluster.cxx
+++ b/SuperaMCParticleCluster.cxx
@@ -56,6 +56,8 @@ namespace larcv {
     _check_particle_validity = cfg.get<bool>("CheckParticleValidity",true);
     _merge_shower_delta = cfg.get<bool>("MergeShowerDelta", true);
 
+    _useOrigTrackID = cfg.get<bool>("UseOrigTrackID", false);
+
     auto cryostat_v   = cfg.get<std::vector<unsigned short> >("CryostatList");
     auto tpc_v        = cfg.get<std::vector<unsigned short> >("TPCList"     );
     std::vector<unsigned short> plane_v;
@@ -257,14 +259,15 @@ namespace larcv {
       auto const& sedep = sedep_v.at(sedep_idx);
 
       VoxelID_t vox_id = meta.id(sedep.X(), sedep.Y(), sedep.Z());
+      int track_id = abs(sedep.TrackID());
       if(vox_id == larcv::kINVALID_VOXELID || !_world_bounds.contains(sedep.X(),sedep.Y(),sedep.Z())) {
-        LARCV_DEBUG() << "Skipping sedep from track id " << sedep.TrackID()
+        LARCV_DEBUG() << "Skipping sedep from track id " << track_id
                 << " E=" << sedep.Energy()
                 << " pos=(" << sedep.X() << "," << sedep.Y() << "," << sedep.Z() << ")" << std::endl;
         continue;
       }
       //ctr_a.insert(vox_id);
-      LARCV_DEBUG() << "Recording sedep from track id " << sedep.TrackID()
+      LARCV_DEBUG() << "Recording sedep from track id " << track_id
         << " E=" << sedep.Energy() << std::endl;
 
       supera::EDep pt;
@@ -280,7 +283,6 @@ namespace larcv {
   double dz = sedep.EndZ() - sedep.StartZ();
   pt.dedx = pt.e / sqrt(pow(dx,2)+pow(dy,2)+pow(dz,2));
       }*/
-      int track_id = abs(sedep.TrackID());
       if(track_id >= ((int)(trackid2index.size()))) {
         bad_sedep_counter++;
         missing_trackid.insert(track_id);
@@ -483,7 +485,7 @@ namespace larcv {
             }
           }
           */
-          int track_id = abs(edep.trackID);
+          int track_id = abs(_useOrigTrackID ? edep.origTrackID : edep.trackID);
           if(track_id >= ((int)(trackid2index.size()))) {
             ++ctr_missing_trackid;
             missing_trackid.insert(track_id);

--- a/SuperaMCParticleCluster.cxx
+++ b/SuperaMCParticleCluster.cxx
@@ -45,9 +45,9 @@ namespace larcv {
     _edep_threshold = cfg.get<double>("EnergyDepositThreshold",0.01);
     _projection_id = cfg.get<int>("ProjectionID",-1);
 
-		// If we want to use SED, we have the option
-		// to use SEDLite.
-		_use_sed = cfg.get<bool>("UseSimEnergyDeposit", true);
+    // If we want to use SED, we have the option
+    // to use SEDLite.
+    _use_sed = cfg.get<bool>("UseSimEnergyDeposit", true);
     _use_sed_lite = cfg.get<bool>("UseSimEnergyDepositLite", false);
 
     _use_sed_points = cfg.get<bool>("UseSimEnergyDepositPoints");
@@ -70,9 +70,9 @@ namespace larcv {
       auto const& t = tpc_v[idx];
       auto const& cryostat = geop->Cryostat(c);
       if(!cryostat.HasTPC(t)) {
-	LARCV_CRITICAL() << "Invalid TPCList: cryostat " << c
-			 << " does not contain tpc " << t << std::endl;
-	throw larbys();
+        LARCV_CRITICAL() << "Invalid TPCList: cryostat " << c
+               << " does not contain tpc " << t << std::endl;
+        throw larbys();
       }
       auto const& tpcabox = cryostat.TPC(t).ActiveBoundingBox();
       if(min_pt.x > tpcabox.MinX()) min_pt.x = tpcabox.MinX();
@@ -93,32 +93,32 @@ namespace larcv {
       auto& scan_cryo = _scan[c];
       scan_cryo.resize(cryostat.NTPC());
       for(size_t tpcid=0; tpcid<scan_cryo.size(); ++tpcid) {
-	auto const& tpc = cryostat.TPC(tpcid);
-	auto& scan_tpc = scan_cryo[tpcid];
-	scan_tpc.resize(tpc.Nplanes(),-1);
+        auto const& tpc = cryostat.TPC(tpcid);
+        auto& scan_tpc = scan_cryo[tpcid];
+        scan_tpc.resize(tpc.Nplanes(),-1);
       }
     }
     //for(size_t cryo_id=0; cryo_id<_scan.size(); ++cryo_id){
     _valid_nplanes = 0;
     if(plane_v.size()) {
       for(size_t idx=0; idx<cryostat_v.size(); ++idx) {
-	auto const& c = cryostat_v[idx];
-	auto const& t = tpc_v[idx];
-	auto const& p = plane_v[idx];
-	auto const& cryostat = geop->Cryostat(c);
-	if(!cryostat.HasTPC(t)) {
-	  LARCV_CRITICAL() << "Invalid TPCList: cryostat " << c
-			   << " does not contain tpc " << t << std::endl;
-	  throw larbys();
-	}
-	auto const& tpc = cryostat.TPC(t);
-	if(!tpc.HasPlane(p)) {
-	  LARCV_CRITICAL() << "Invalid TPCList: cryostat " << c << " TPC " << t
-			   << " does not contain plane " << p << std::endl;
-	  throw larbys();
-	}
-	_scan[c][t][p] = _valid_nplanes;
-	++_valid_nplanes;
+        auto const& c = cryostat_v[idx];
+        auto const& t = tpc_v[idx];
+        auto const& p = plane_v[idx];
+        auto const& cryostat = geop->Cryostat(c);
+        if(!cryostat.HasTPC(t)) {
+          LARCV_CRITICAL() << "Invalid TPCList: cryostat " << c
+               << " does not contain tpc " << t << std::endl;
+          throw larbys();
+        }
+        auto const& tpc = cryostat.TPC(t);
+        if(!tpc.HasPlane(p)) {
+          LARCV_CRITICAL() << "Invalid TPCList: cryostat " << c << " TPC " << t
+               << " does not contain plane " << p << std::endl;
+          throw larbys();
+        }
+        _scan[c][t][p] = _valid_nplanes;
+        ++_valid_nplanes;
       }
     }
 
@@ -128,17 +128,17 @@ namespace larcv {
       _true2reco=new SuperaTrue2RecoVoxel3D("SuperaTrue2RecoVoxel3D");
       _true2reco->configure(pset);
       for(size_t i=0; i<(size_t)(::supera::LArDataType_t::kLArDataTypeMax); ++i) {
-	auto dtype = (supera::LArDataType_t)i;
-	auto name1 = this->LArDataLabel(dtype);
-	auto name2 = _true2reco->LArDataLabel(dtype);
-	if(name1.empty() && name2.empty()) continue;
-	else if(name1.empty()) this->Request(dtype,name2);
-	else if(name2.empty() || name1 == name2) continue;
-	else {
-	  LARCV_CRITICAL() << "LArData type " << i << " request conflict: "
-			   << name1 << " vs. " << name2 << std::endl;
-	  throw std::exception();
-	}
+        auto dtype = (supera::LArDataType_t)i;
+        auto name1 = this->LArDataLabel(dtype);
+        auto name2 = _true2reco->LArDataLabel(dtype);
+        if(name1.empty() && name2.empty()) continue;
+        else if(name1.empty()) this->Request(dtype,name2);
+        else if(name2.empty() || name1 == name2) continue;
+        else {
+          LARCV_CRITICAL() << "LArData type " << i << " request conflict: "
+               << name1 << " vs. " << name2 << std::endl;
+          throw std::exception();
+        }
       }
     }
   }
@@ -177,7 +177,7 @@ namespace larcv {
       int mother_index   = -1;
       int track_id       = mcpart.TrackId();
       if(mcpart.Mother() < ((int)(trackid2index.size())))
-	mother_index = trackid2index[mcpart.Mother()];
+        mother_index = trackid2index[mcpart.Mother()];
 
       //if(pdg_code != -11 && pdg_code != 11 && pdg_code != 22) continue;
       if(pdg_code > 1000000) continue;
@@ -186,49 +186,49 @@ namespace larcv {
       grp.part = this->MakeParticle(mcpart);
 
       if(mother_index >= 0)
-	grp.part.parent_pdg_code(parent_pdg_v[index]);
+        grp.part.parent_pdg_code(parent_pdg_v[index]);
       grp.valid=true;
 
       if(pdg_code == 22 || pdg_code == 11) {
-	if(pdg_code == 22) {
-	  // photon ... reset first, last, and end position
-	  grp.type = supera::kPhoton;
-	  grp.part.first_step(invalid_part.first_step());
-	  grp.part.last_step(invalid_part.last_step());
-	  grp.part.end_position(invalid_part.end_position());
-	}
-	else if(pdg_code == 11) {
+        if(pdg_code == 22) {
+          // photon ... reset first, last, and end position
+          grp.type = supera::kPhoton;
+          grp.part.first_step(invalid_part.first_step());
+          grp.part.last_step(invalid_part.last_step());
+          grp.part.end_position(invalid_part.end_position());
+        }
+        else if(pdg_code == 11) {
 
-	  std::string prc = mcpart.Process();
-	  if( prc == "muIoni" || prc == "hIoni" || prc == "muPairProd" )
-	    grp.type = supera::kDelta;
-	  else if( prc == "muMinusCaptureAtRest" || prc == "muPlusCaptureAtRest" || prc == "Decay" )
-	    grp.type = supera::kDecay;
-	  else if( prc == "compt"  )
-	    grp.type = supera::kCompton;
-	  else if( prc == "phot"   )
-	    grp.type = supera::kPhotoElectron;
-	  else if( prc == "eIoni"  )
-	    grp.type = supera::kIonization;
-	  else if( prc == "conv"   )
-	    grp.type = supera::kConversion;
-	  else if( prc == "primary")
-	    grp.type = supera::kPrimary;
-	  else
-	    grp.type = supera::kOtherShower;
-	}
-	result[track_id] = grp;
+          std::string prc = mcpart.Process();
+          if( prc == "muIoni" || prc == "hIoni" || prc == "muPairProd" )
+            grp.type = supera::kDelta;
+          else if( prc == "muMinusCaptureAtRest" || prc == "muPlusCaptureAtRest" || prc == "Decay" )
+            grp.type = supera::kDecay;
+          else if( prc == "compt"  )
+            grp.type = supera::kCompton;
+          else if( prc == "phot"   )
+            grp.type = supera::kPhotoElectron;
+          else if( prc == "eIoni"  )
+            grp.type = supera::kIonization;
+          else if( prc == "conv"   )
+            grp.type = supera::kConversion;
+          else if( prc == "primary")
+            grp.type = supera::kPrimary;
+          else
+            grp.type = supera::kOtherShower;
+        }
+        result[track_id] = grp;
       }
       else {
-	grp.type = supera::kTrack;
-	if(grp.part.pdg_code() == 2112)
-	  grp.type = supera::kNeutron;
-	result[track_id] = grp;
+        grp.type = supera::kTrack;
+        if(grp.part.pdg_code() == 2112)
+          grp.type = supera::kNeutron;
+        result[track_id] = grp;
       }
 
-      std::cout<<"Track ID " << grp.part.track_id() << " PDG " << grp.part.pdg_code() << " " << grp.part.creation_process()
-	       <<" ... parent Track ID " << grp.part.parent_track_id() << " PDG " << grp.part.parent_pdg_code() << std::endl;
-
+      /*std::cout<<"Track ID " << grp.part.track_id() << " PDG " << grp.part.pdg_code() << " " << grp.part.creation_process()
+         <<" ... parent Track ID " << grp.part.parent_track_id() << " PDG " << grp.part.parent_pdg_code() << std::endl;
+      */
     }
 
     // fill parentage information
@@ -237,8 +237,8 @@ namespace larcv {
   }
 
   template<typename sed_type> void SuperaMCParticleCluster::AnalyzeSimEnergyDeposit(const larcv::Voxel3DMeta& meta,
-							std::vector<supera::ParticleGroup>& part_grp_v,
-							larcv::IOManager& mgr)
+              std::vector<supera::ParticleGroup>& part_grp_v,
+              larcv::IOManager& mgr)
   {
     //std::set<size_t> ctr_a, ctr_b;
     auto const& sedep_v = LArData<sed_type>();
@@ -258,14 +258,14 @@ namespace larcv {
 
       VoxelID_t vox_id = meta.id(sedep.X(), sedep.Y(), sedep.Z());
       if(vox_id == larcv::kINVALID_VOXELID || !_world_bounds.contains(sedep.X(),sedep.Y(),sedep.Z())) {
-	LARCV_DEBUG() << "Skipping sedep from track id " << sedep.TrackID()
-		      << " E=" << sedep.Energy()
-		      << " pos=(" << sedep.X() << "," << sedep.Y() << "," << sedep.Z() << ")" << std::endl;
-	continue;
+        LARCV_DEBUG() << "Skipping sedep from track id " << sedep.TrackID()
+                << " E=" << sedep.Energy()
+                << " pos=(" << sedep.X() << "," << sedep.Y() << "," << sedep.Z() << ")" << std::endl;
+        continue;
       }
       //ctr_a.insert(vox_id);
       LARCV_DEBUG() << "Recording sedep from track id " << sedep.TrackID()
-		    << " E=" << sedep.Energy() << std::endl;
+        << " E=" << sedep.Energy() << std::endl;
 
       supera::EDep pt;
       pt.x = sedep.X();
@@ -274,102 +274,87 @@ namespace larcv {
       pt.t = sedep.T();
       pt.e = sedep.Energy();
       /* Commenting out for now because of SEDLite
-			 if(_store_dedx) {
-	double dx = sedep.EndX() - sedep.StartX();
-	double dy = sedep.EndY() - sedep.StartY();
-	double dz = sedep.EndZ() - sedep.StartZ();
-	pt.dedx = pt.e / sqrt(pow(dx,2)+pow(dy,2)+pow(dz,2));
+       if(_store_dedx) {
+  double dx = sedep.EndX() - sedep.StartX();
+  double dy = sedep.EndY() - sedep.StartY();
+  double dz = sedep.EndZ() - sedep.StartZ();
+  pt.dedx = pt.e / sqrt(pow(dx,2)+pow(dy,2)+pow(dz,2));
       }*/
       int track_id = abs(sedep.TrackID());
-			if (track_id == 4 || track_id == 8 || track_id == 9 || track_id == 10) std::cout << "Found " << track_id << std::endl;
       if(track_id >= ((int)(trackid2index.size()))) {
-	bad_sedep_counter++;
-	missing_trackid.insert(track_id);
-	continue;
+        bad_sedep_counter++;
+        missing_trackid.insert(track_id);
+        continue;
       }
 
       auto& grp = part_grp_v[track_id];
       if(!grp.valid) continue;
-      /*
-      static std::set<unsigned long long> kazu;
-      if(vox_id != larcv::kINVALID_VOXELID) {
-	kazu.insert(vox_id);
-	std::cout<<kazu.size()<<std::endl;
-      }
-
-      if(grp.part.track_id() > 1) {
-	std::cout<<grp.part.pdg_code()<<" ... "<<grp.part.creation_process()<<" ... "<<std::flush;
-	if(vox_id == larcv::kINVALID_VOXELID) std::cout<<"INVALID"<<std::endl;
-	else std::cout<<"("<<meta.id_to_x_index(vox_id)<<","<<meta.id_to_y_index(vox_id)<<","<<meta.id_to_z_index(vox_id)<<")"<<std::endl;
-      }
-      */
-      // translate voxid if needed
 
       // translate voxid if needed
       if(!use_true2reco) {
-	// no need to translate
-	grp.vs.emplace(vox_id,pt.e,true);
-	if(_store_dedx)
-	  grp.dedx.emplace(vox_id,pt.dedx,true);
-	grp.AddEDep(pt);
+        // no need to translate
+        grp.vs.emplace(vox_id,pt.e,true);
+        if(_store_dedx)
+          grp.dedx.emplace(vox_id,pt.dedx,true);
+        grp.AddEDep(pt);
       }
       else if(track_id >= (int)(true2reco_v.size()) || true2reco_v[track_id].empty()) {
-	// translation doesn't exist for this voxel
-	++bad_sedep_counter;
-	++bad_sedep_counter2;
+        // translation doesn't exist for this voxel
+        ++bad_sedep_counter;
+        ++bad_sedep_counter2;
       }
       else {
-	auto const& true2reco_m = true2reco_v[track_id];
-	auto true2reco_iter = true2reco_m.find(vox_id);
-	if(true2reco_iter == true2reco_m.end() || true2reco_iter->second.empty()) {
-	  // translation doesn't exist for this voxel
-	  ++bad_sedep_counter;
-		++bad_sedep_counter3;
-	}
-	else{
-	  //ctr_b.insert(vox_id);
-	  // translation exists
-	  larcv::Point3D edep_pos(pt.x,pt.y,pt.z);
-	  larcv::Point3D position(0.,0.,0.);
-	  double dist_min = 1.e20;
-	  //double reco_sum = vs.sum();
-	  for(auto const& reco_vox_id : true2reco_iter->second) {
-	    auto vox_position = meta.position(reco_vox_id);
-	    double dist = vox_position.squared_distance(edep_pos);
-	    if(dist_min == 1.e20) {
-	      position = vox_position;
-	      dist_min = dist;
-	    } else {
-	      if(dist < dist_min) {
-		dist_min = dist;
-		position = vox_position;
-	      }
-	    }
-	    //grp.vs.emplace(vox.id(),pt.e * vox.value()/reco_sum,true);
-	    grp.vs.emplace(reco_vox_id,pt.e/true2reco_iter->second.size(),true);
-	    if(_store_dedx)
-	      grp.dedx.emplace(reco_vox_id,pt.dedx/true2reco_iter->second.size(),true);
-	  }
-	  pt.x = position.x;
-	  pt.y = position.y;
-	  pt.z = position.z;
-	  grp.AddEDep(pt);
-	}
+        auto const& true2reco_m = true2reco_v[track_id];
+        auto true2reco_iter = true2reco_m.find(vox_id);
+        if(true2reco_iter == true2reco_m.end() || true2reco_iter->second.empty()) {
+          // translation doesn't exist for this voxel
+          ++bad_sedep_counter;
+          ++bad_sedep_counter3;
+        }
+        else{
+          //ctr_b.insert(vox_id);
+          // translation exists
+          larcv::Point3D edep_pos(pt.x,pt.y,pt.z);
+          larcv::Point3D position(0.,0.,0.);
+          double dist_min = 1.e20;
+          //double reco_sum = vs.sum();
+          for(auto const& reco_vox_id : true2reco_iter->second) {
+            auto vox_position = meta.position(reco_vox_id);
+            double dist = vox_position.squared_distance(edep_pos);
+            if(dist_min == 1.e20) {
+              position = vox_position;
+              dist_min = dist;
+            } else {
+              if(dist < dist_min) {
+          dist_min = dist;
+          position = vox_position;
+              }
+            }
+            //grp.vs.emplace(vox.id(),pt.e * vox.value()/reco_sum,true);
+            grp.vs.emplace(reco_vox_id,pt.e/true2reco_iter->second.size(),true);
+            if(_store_dedx)
+              grp.dedx.emplace(reco_vox_id,pt.dedx/true2reco_iter->second.size(),true);
+          }
+          pt.x = position.x;
+          pt.y = position.y;
+          pt.z = position.z;
+          grp.AddEDep(pt);
+        }
       }
     }
     if(bad_sedep_counter) {
       LARCV_WARNING() << bad_sedep_counter << " / " << sedep_v.size() << " SimEnergyDeposits "
-		      << "(from " << missing_trackid.size() << " particles) did not find corresponding MCParticle!"
-		      << std::endl;
-			LARCV_WARNING() << bad_sedep_counter << " " << bad_sedep_counter2 << " " << bad_sedep_counter3 << std::endl;
-			for (auto trackid : missing_trackid) std::cout << trackid << std::endl;
+          << "(from " << missing_trackid.size() << " particles) did not find corresponding MCParticle!"
+          << std::endl;
+      LARCV_WARNING() << bad_sedep_counter << " " << bad_sedep_counter2 << " " << bad_sedep_counter3 << std::endl;
+      for (auto trackid : missing_trackid) std::cout << trackid << std::endl;
     }
     //std::cout<<(mgr.get_data<larcv::EventSparseTensor3D>("masked_true")).size()<<" : "<<ctr_a.size()<<" : "<<ctr_b.size()<<std::endl;
 
   }
 
   template<typename sed_type> void SuperaMCParticleCluster::AnalyzeFirstLastStep(const larcv::Voxel3DMeta& meta,
-						     std::vector<supera::ParticleGroup>& part_grp_v)
+                 std::vector<supera::ParticleGroup>& part_grp_v)
   {
     auto const& sedep_v = LArData<sed_type>();
     auto const& trackid2index = _mcpl.TrackIdToIndex();
@@ -381,11 +366,11 @@ namespace larcv {
 
       VoxelID_t vox_id = meta.id(sedep.X(), sedep.Y(), sedep.Z());
       if(vox_id == larcv::kINVALID_VOXELID || !_world_bounds.contains(sedep.X(),sedep.Y(),sedep.Z()))
-	continue;
+        continue;
 
       int track_id = abs(sedep.TrackID());
       if(track_id >= ((int)(trackid2index.size())))
-	continue;
+        continue;
 
       supera::EDep pt;
       pt.x = sedep.X();
@@ -402,14 +387,14 @@ namespace larcv {
     }
     /*
     std::cout<<"T " << tmin << " => " << tmax
-	     <<" ... X " << xmin << " => " << xmax << std::endl;
+       <<" ... X " << xmin << " => " << xmax << std::endl;
     */
   }
 
 
   void SuperaMCParticleCluster::AnalyzeSimChannel(const larcv::Voxel3DMeta& meta3d,
-						  std::vector<supera::ParticleGroup>& part_grp_v,
-						  larcv::IOManager& mgr)
+              std::vector<supera::ParticleGroup>& part_grp_v,
+              larcv::IOManager& mgr)
   {
     //std::set<size_t> ctr_a, ctr_b;
 
@@ -460,8 +445,8 @@ namespace larcv {
 
       for (auto const tick_ides : sch.TDCIDEMap()) {
 
-	//x_pos = (supera::TPCTDC2Tick(tick_ides.first) + time_offset) * supera::TPCTickPeriod()  * supera::DriftVelocity();
-	double x_pos = supera::TPCTDC2Tick(tick_ides.first) * supera::TPCTickPeriod()  * supera::DriftVelocity();
+        //x_pos = (supera::TPCTDC2Tick(tick_ides.first) + time_offset) * supera::TPCTickPeriod()  * supera::DriftVelocity();
+        double x_pos = supera::TPCTDC2Tick(tick_ides.first) * supera::TPCTickPeriod()  * supera::DriftVelocity();
         //std::cout << tick_ides.first << " : " << supera::TPCTDC2Tick(tick_ides.first) << " : " << time_offset << " : " << x_pos << std::flush;
         //std::cout << (supera::TPCTDC2Tick(tick_ides.first) + time_offset) << std::endl
         //<< (supera::TPCTDC2Tick(tick_ides.first) + time_offset) * supera::TPCTickPeriod() << std::endl
@@ -470,196 +455,190 @@ namespace larcv {
 
         for (auto const& edep : tick_ides.second) {
 
-	  ctr_total_ide++;
+          ctr_total_ide++;
 
-	  supera::EDep pt;
-	  pt.x = x_pos;
-	  pt.y = edep.y;
-	  pt.z = edep.z;
-	  pt.e = edep.energy;
+          supera::EDep pt;
+          pt.x = x_pos;
+          pt.y = edep.y;
+          pt.z = edep.z;
+          pt.e = edep.energy;
 
-	  if(_use_true_pos)
-	    pt.x = edep.x;
+          if(_use_true_pos)
+            pt.x = edep.x;
 
-	  double wire_pos = larcv::kINVALID_DOUBLE;
-	  double time_pos = larcv::kINVALID_DOUBLE;
-	  skipped2d = skipped3d = false;
-          //supera::ApplySCE(x,y,z);
-          //std::cout << " ... " << x << std::end;l
-	  /*
-	  if(vs2d_idx==0) {
-	    auto const& meta2d = _meta2d_v[vs2d_idx];
-	    wire_pos = wid.Wire;
-	    time_pos = supera::TPCTDC2Tick(tick_ides.first);
-	    if( (meta2d.min_x() <= wire_pos && wire_pos < meta2d.max_x()) &&
-		(meta2d.min_y() <= time_pos && time_pos < meta2d.max_y()) ) {
-	      auto vox2d_id = meta2d.id(wire_pos,time_pos);
-	      kvs.emplace(vox2d_id,pt.e,true);
-	    }
-	  }
-	  */
-	  int track_id = abs(edep.trackID);
-	  if(track_id >= ((int)(trackid2index.size()))) {
-	    ++ctr_missing_trackid;
-	    missing_trackid.insert(track_id);
-	    continue;
-	  }
+          double wire_pos = larcv::kINVALID_DOUBLE;
+          double time_pos = larcv::kINVALID_DOUBLE;
+          skipped2d = skipped3d = false;
+                //supera::ApplySCE(x,y,z);
+                //std::cout << " ... " << x << std::end;l
+          /*
+          if(vs2d_idx==0) {
+            auto const& meta2d = _meta2d_v[vs2d_idx];
+            wire_pos = wid.Wire;
+            time_pos = supera::TPCTDC2Tick(tick_ides.first);
+            if( (meta2d.min_x() <= wire_pos && wire_pos < meta2d.max_x()) &&
+          (meta2d.min_y() <= time_pos && time_pos < meta2d.max_y()) ) {
+              auto vox2d_id = meta2d.id(wire_pos,time_pos);
+              kvs.emplace(vox2d_id,pt.e,true);
+            }
+          }
+          */
+          int track_id = abs(edep.trackID);
+          if(track_id >= ((int)(trackid2index.size()))) {
+            ++ctr_missing_trackid;
+            missing_trackid.insert(track_id);
+            continue;
+          }
 
-	  auto& grp = part_grp_v[track_id];
-	  if(!grp.valid) {
-	    ++ctr_invalid_trackid;
-	    continue;
-	  }
-	  /*
-	  if(vs2d_idx==0) {
-	    auto const& meta2d = _meta2d_v[vs2d_idx];
-	    wire_pos = wid.Wire;
-	    time_pos = supera::TPCTDC2Tick(tick_ides.first);
-	    if( (meta2d.min_x() <= wire_pos && wire_pos < meta2d.max_x()) &&
-		(meta2d.min_y() <= time_pos && time_pos < meta2d.max_y()) ) {
-	      auto vox2d_id = meta2d.id(wire_pos,time_pos);
-	      kvs.emplace(vox2d_id,pt.e,true);
-	    }
-	  }
-	  */
-	  if(analyze3d) {
-	    VoxelID_t vox_id = meta3d.id(pt.x, pt.y, pt.z);
-	    /*
-	    static std::set<unsigned long long> kazu;
-	    if(vox_id != larcv::kINVALID_VOXELID) {
-	      kazu.insert(vox_id);
-	      std::cout<<kazu.size()<<std::endl;
-	    }
+          auto& grp = part_grp_v[track_id];
+          if(!grp.valid) {
+            ++ctr_invalid_trackid;
+            continue;
+          }
+          /*
+          if(vs2d_idx==0) {
+            auto const& meta2d = _meta2d_v[vs2d_idx];
+            wire_pos = wid.Wire;
+            time_pos = supera::TPCTDC2Tick(tick_ides.first);
+            if( (meta2d.min_x() <= wire_pos && wire_pos < meta2d.max_x()) &&
+          (meta2d.min_y() <= time_pos && time_pos < meta2d.max_y()) ) {
+              auto vox2d_id = meta2d.id(wire_pos,time_pos);
+              kvs.emplace(vox2d_id,pt.e,true);
+            }
+          }
+          */
+          if(analyze3d) {
+            VoxelID_t vox_id = meta3d.id(pt.x, pt.y, pt.z);
+            /*
+            static std::set<unsigned long long> kazu;
+            if(vox_id != larcv::kINVALID_VOXELID) {
+              kazu.insert(vox_id);
+              std::cout<<kazu.size()<<std::endl;
+            }
 
-	    if(grp.part.track_id() > 1) {
-	    std::cout<<grp.part.pdg_code()<<" ... "<<grp.part.creation_process()<<" ... "<<std::flush;
-	      if(vox_id == larcv::kINVALID_VOXELID) std::cout<<"INVALID"<<std::endl;
-	      else std::cout<<"("<<meta3d.id_to_x_index(vox_id)<<","<<meta3d.id_to_y_index(vox_id)<<","<<meta3d.id_to_z_index(vox_id)<<")"<<std::endl;
-	      }
-	    */
-	    if(vox_id == larcv::kINVALID_VOXELID) {
-	      skipped3d = true;
-	      ++ctr_invalid_3d;
-	    }else{
-	      //ctr_a.insert(vox_id);
-	      // translate voxid if needed
-	      if(!use_true2reco) {
-		// no need to translate
-		grp.vs.emplace(vox_id,pt.e,true);
-		grp.AddEDep(pt);
-	      }
-	      else if(track_id >= (int)(true2reco_v.size()) || true2reco_v[track_id].empty()) {
-		// translation doesn't exist for this voxel
-		skipped3d = true;
-		++ctr_invalid_3d;
-	      }
-	      else {
-		auto const& true2reco_m = true2reco_v[track_id];
-		auto true2reco_iter = true2reco_m.find(vox_id);
-		if(true2reco_iter == true2reco_m.end() || true2reco_iter->second.empty()) {
-		  // translation doesn't exist for this voxel
-		  skipped3d = true;
-		  ++ctr_invalid_3d;
-		}
-		else{
-		  //ctr_b.insert(vox_id);
-		  // translation exists
-		  larcv::Point3D edep_pos(pt.x,pt.y,pt.z);
-		  larcv::Point3D position(0.,0.,0.);
-		  double dist_min = 1.e20;
-		  //double reco_sum = vs.sum();
-		  for(auto const& reco_vox_id : true2reco_iter->second) {
-		    auto vox_position = meta3d.position(reco_vox_id);
-		    double dist = vox_position.squared_distance(edep_pos);
-		    if(dist_min == 1.e20) {
-		      position = vox_position;
-		      dist_min = dist;
-		    } else {
-		      if(dist < dist_min) {
-			dist_min = dist;
-			position = vox_position;
-		      }
-		    }
-		    //grp.vs.emplace(vox.id(),pt.e * vox.value()/reco_sum,true);
-		    grp.vs.emplace(reco_vox_id,pt.e/true2reco_iter->second.size(),true);
-		  }
-		  pt.x = position.x;
-		  pt.y = position.y;
-		  pt.z = position.z;
-		  grp.AddEDep(pt);
-		}
-	      }
-	    }
-	  }
-	  if(analyze2d) {
-	    VoxelID_t vox2d_id = larcv::kINVALID_VOXELID;
-	    auto const& meta2d = _meta2d_v[vs2d_idx];
-	    wire_pos = wid.Wire;
-	    time_pos = supera::TPCTDC2Tick(tick_ides.first);
+            if(grp.part.track_id() > 1) {
+            std::cout<<grp.part.pdg_code()<<" ... "<<grp.part.creation_process()<<" ... "<<std::flush;
+              if(vox_id == larcv::kINVALID_VOXELID) std::cout<<"INVALID"<<std::endl;
+              else std::cout<<"("<<meta3d.id_to_x_index(vox_id)<<","<<meta3d.id_to_y_index(vox_id)<<","<<meta3d.id_to_z_index(vox_id)<<")"<<std::endl;
+              }
+            */
+            if(vox_id == larcv::kINVALID_VOXELID) {
+              skipped3d = true;
+              ++ctr_invalid_3d;
+            }else{
+              //ctr_a.insert(vox_id);
+              // translate voxid if needed
+              if(!use_true2reco) {
+                // no need to translate
+                grp.vs.emplace(vox_id,pt.e,true);
+                grp.AddEDep(pt);
+              }
+              else if(track_id >= (int)(true2reco_v.size()) || true2reco_v[track_id].empty()) {
+                // translation doesn't exist for this voxel
+                skipped3d = true;
+                ++ctr_invalid_3d;
+              }
+              else {
+                auto const& true2reco_m = true2reco_v[track_id];
+                auto true2reco_iter = true2reco_m.find(vox_id);
+                if(true2reco_iter == true2reco_m.end() || true2reco_iter->second.empty()) {
+                  // translation doesn't exist for this voxel
+                  skipped3d = true;
+                  ++ctr_invalid_3d;
+                }
+                else{
+                  //ctr_b.insert(vox_id);
+                  // translation exists
+                  larcv::Point3D edep_pos(pt.x,pt.y,pt.z);
+                  larcv::Point3D position(0.,0.,0.);
+                  double dist_min = 1.e20;
+                  //double reco_sum = vs.sum();
+                  for(auto const& reco_vox_id : true2reco_iter->second) {
+                    auto vox_position = meta3d.position(reco_vox_id);
+                    double dist = vox_position.squared_distance(edep_pos);
+                    if(dist_min == 1.e20) {
+                      position = vox_position;
+                      dist_min = dist;
+                    } else {
+                      if(dist < dist_min) {
+                  dist_min = dist;
+                  position = vox_position;
+                      }
+                    }
+                    //grp.vs.emplace(vox.id(),pt.e * vox.value()/reco_sum,true);
+                    grp.vs.emplace(reco_vox_id,pt.e/true2reco_iter->second.size(),true);
+                  }
+                  pt.x = position.x;
+                  pt.y = position.y;
+                  pt.z = position.z;
+                  grp.AddEDep(pt);
+                }
+              }
+            }
+          }
+          if(analyze2d) {
+            VoxelID_t vox2d_id = larcv::kINVALID_VOXELID;
+            auto const& meta2d = _meta2d_v[vs2d_idx];
+            wire_pos = wid.Wire;
+            time_pos = supera::TPCTDC2Tick(tick_ides.first);
 
-	    if(pt.x < xrange2d.first ) xrange2d.first  = pt.x;
-	    if(pt.x > xrange2d.second) xrange2d.second = pt.x;
-	    if(time_pos < trange2d.first ) trange2d.first  = time_pos;
-	    if(time_pos > trange2d.second) trange2d.second = time_pos;
+            if(pt.x < xrange2d.first ) xrange2d.first  = pt.x;
+            if(pt.x > xrange2d.second) xrange2d.second = pt.x;
+            if(time_pos < trange2d.first ) trange2d.first  = time_pos;
+            if(time_pos > trange2d.second) trange2d.second = time_pos;
 
-	    if( (meta2d.min_x() <= wire_pos && wire_pos < meta2d.max_x()) &&
-		(meta2d.min_y() <= time_pos && time_pos < meta2d.max_y()) )
-	      vox2d_id = meta2d.id(wire_pos,time_pos);
+            if( (meta2d.min_x() <= wire_pos && wire_pos < meta2d.max_x()) &&
+          (meta2d.min_y() <= time_pos && time_pos < meta2d.max_y()) )
+              vox2d_id = meta2d.id(wire_pos,time_pos);
 
-	    //if(track_id == 7305 || track_id == 7311)
-	    //std::cout << "track " << track_id << " (wire,time) = (" << wire_pos << "," << time_pos << ") ... vox2d id " << vox2d_id << std::endl;
+            //if(track_id == 7305 || track_id == 7311)
+            //std::cout << "track " << track_id << " (wire,time) = (" << wire_pos << "," << time_pos << ") ... vox2d id " << vox2d_id << std::endl;
 
-	    if(vox2d_id != larcv::kINVALID_VOXELID) {
-	      if(pt.x < recorded_xrange2d.first ) recorded_xrange2d.first  = pt.x;
-	      if(pt.x > recorded_xrange2d.second) recorded_xrange2d.second = pt.x;
-	      if(time_pos < recorded_trange2d.first ) recorded_trange2d.first  = time_pos;
-	      if(time_pos > recorded_trange2d.second) recorded_trange2d.second = time_pos;
-	      grp.vs2d_v[vs2d_idx].emplace(vox2d_id,edep.numElectrons,true);
-	    }
-	    else {
-	      skipped2d = true;
-	      ++ctr_invalid_2d;
-	    }
-	  }
+            if(vox2d_id != larcv::kINVALID_VOXELID) {
+              if(pt.x < recorded_xrange2d.first ) recorded_xrange2d.first  = pt.x;
+              if(pt.x > recorded_xrange2d.second) recorded_xrange2d.second = pt.x;
+              if(time_pos < recorded_trange2d.first ) recorded_trange2d.first  = time_pos;
+              if(time_pos > recorded_trange2d.second) recorded_trange2d.second = time_pos;
+              grp.vs2d_v[vs2d_idx].emplace(vox2d_id,edep.numElectrons,true);
+            }
+            else {
+              skipped2d = true;
+              ++ctr_invalid_2d;
+            }
+          }
 
-	  LARCV_DEBUG() << "IDE ... TrackID " << edep.trackID << " E " << edep.energy << " Q " << edep.numElectrons << std::endl;
+          LARCV_DEBUG() << "IDE ... TrackID " << edep.trackID << " E " << edep.energy << " Q " << edep.numElectrons << std::endl;
 
-	  if(skipped2d || skipped3d) {
+          if(skipped2d || skipped3d) {
 
-	    LARCV_INFO() << "Skipped 2d/3d " << (skipped2d ? "1" : "0") << "/" << (skipped3d ? "1" : "0") << " TrackID " << edep.trackID
-			 << " pos (" << pt.x << "," << pt.y << "," << pt.z << ")"
-			 << " ... TDC " << tick_ides.first << " => Tick " << time_pos
-			 << "... Wire " << wid.Wire
-			 <<std::endl;
-	  }
+            LARCV_INFO() << "Skipped 2d/3d " << (skipped2d ? "1" : "0") << "/" << (skipped3d ? "1" : "0") << " TrackID " << edep.trackID
+             << " pos (" << pt.x << "," << pt.y << "," << pt.z << ")"
+             << " ... TDC " << tick_ides.first << " => Tick " << time_pos
+             << "... Wire " << wid.Wire
+             <<std::endl;
+          }
 
-	}
+        }
       }
       //std::cout<<" done" << std::endl;
     }
 
     if(ctr_missing_trackid || ctr_invalid_trackid || ctr_invalid_2d || ctr_invalid_3d) {
       LARCV_WARNING() << "Total IDE ctr " << ctr_total_ide << std::endl
-		      << " ... due to missing track ID " << ctr_missing_trackid
-		      << " from " << missing_trackid.size() << " track IDs" << std::endl
-		      << " ... due to invalid particle " << ctr_invalid_trackid << std::endl
-		      << " ... due to invalid 2d index " << ctr_invalid_2d << std::endl
-		      << " ... due to invalid 3d index " << ctr_invalid_3d << std::endl
-		      << std::endl;
+          << " ... due to missing track ID " << ctr_missing_trackid
+          << " from " << missing_trackid.size() << " track IDs" << std::endl
+          << " ... due to invalid particle " << ctr_invalid_trackid << std::endl
+          << " ... due to invalid 2d index " << ctr_invalid_2d << std::endl
+          << " ... due to invalid 3d index " << ctr_invalid_3d << std::endl
+          << std::endl;
       if(ctr_invalid_2d) {
-	LARCV_WARNING() << "  X range: " << xrange2d.first << " => " << xrange2d.second
-			<< " ... T range: " << trange2d.first << " => " << trange2d.second << std::endl
-			<< " Recorded: " << recorded_xrange2d.first << " => " << recorded_xrange2d.second
-			<< " ... T range: " << recorded_trange2d.first << " => " << recorded_trange2d.second << std::endl;
+  LARCV_WARNING() << "  X range: " << xrange2d.first << " => " << xrange2d.second
+      << " ... T range: " << trange2d.first << " => " << trange2d.second << std::endl
+      << " Recorded: " << recorded_xrange2d.first << " => " << recorded_xrange2d.second
+      << " ... T range: " << recorded_trange2d.first << " => " << recorded_trange2d.second << std::endl;
 
       }
     }
-    //std::cout<<(mgr.get_data<larcv::EventSparseTensor3D>("masked_true")).size()<<" : "<<ctr_a.size()<<" : "<<ctr_b.size()<<std::endl;
-    /*
-    auto out_data = (larcv::EventSparseTensor2D*)(mgr.get_data("sparse2d","kazu"));
-    auto kmeta = _meta2d_v[0];
-    out_data->emplace(std::move(kvs),std::move(kmeta));
-    */
   }
 
 
@@ -672,48 +651,48 @@ namespace larcv {
     do {
       merge_ctr = 0;
       for(auto& grp : part_grp_v) {
-	if(!grp.valid) continue;
-	if(grp.type != supera::kIonization) continue;
-	// merge to a valid "parent"
-	bool parent_found = false;
-	int parent_index = grp.part.parent_track_id();
-	int parent_index_before = grp.part.track_id();
-	while(1) {
-	  //std::cout<< "Inspecting: " << grp.part.track_id() << " => " << parent_index << std::endl;
-	  if(parent_index <0) {
-	    LARCV_DEBUG() << "Invalid parent track id " << parent_index
-			  << " Could not find a parent for " << grp.part.track_id() << " PDG " << grp.part.pdg_code()
-			  << " " << grp.part.creation_process() << " E = " << grp.part.energy_init()
-			  << " (" << grp.part.energy_deposit() << ") MeV" << std::endl;
-	    auto const& parent = part_grp_v[parent_index_before].part;
-	    LARCV_DEBUG() << "Previous parent: " << parent.track_id() << " PDG " << parent.pdg_code()
-			  << " " << parent.creation_process()
-			  << std::endl;
-	    parent_found=false;
-	    invalid_ctr++;
-	    break;
-	    //throw std::exception();
-	  }
-	  auto const& parent = part_grp_v[parent_index];
-	  parent_found = parent.valid;
-	  if(parent_found) break;
-	  else{
-	    int ancestor_index = parent.part.parent_track_id();
-	    if(ancestor_index == parent_index) {
-	      LARCV_INFO() << "Particle " << parent_index << " is root and invalid particle..." << std::endl
-			   << "PDG " << parent.part.pdg_code() << " " << parent.part.creation_process() << std::endl;
-	      break;
-	    }
-	    parent_index_before = parent_index;
-	    parent_index = ancestor_index;
-	  }
-	}
-	// if parent is found, merge
-	if(parent_found) {
-	  auto& parent = part_grp_v[parent_index];
-	  parent.Merge(grp);
-	  merge_ctr++;
-	}
+        if(!grp.valid) continue;
+        if(grp.type != supera::kIonization) continue;
+        // merge to a valid "parent"
+        bool parent_found = false;
+        int parent_index = grp.part.parent_track_id();
+        int parent_index_before = grp.part.track_id();
+        while(1) {
+          //std::cout<< "Inspecting: " << grp.part.track_id() << " => " << parent_index << std::endl;
+          if(parent_index <0) {
+            LARCV_DEBUG() << "Invalid parent track id " << parent_index
+              << " Could not find a parent for " << grp.part.track_id() << " PDG " << grp.part.pdg_code()
+              << " " << grp.part.creation_process() << " E = " << grp.part.energy_init()
+              << " (" << grp.part.energy_deposit() << ") MeV" << std::endl;
+            auto const& parent = part_grp_v[parent_index_before].part;
+            LARCV_DEBUG() << "Previous parent: " << parent.track_id() << " PDG " << parent.pdg_code()
+              << " " << parent.creation_process()
+              << std::endl;
+            parent_found=false;
+            invalid_ctr++;
+            break;
+            //throw std::exception();
+          }
+          auto const& parent = part_grp_v[parent_index];
+          parent_found = parent.valid;
+          if(parent_found) break;
+          else{
+            int ancestor_index = parent.part.parent_track_id();
+            if(ancestor_index == parent_index) {
+              LARCV_INFO() << "Particle " << parent_index << " is root and invalid particle..." << std::endl
+               << "PDG " << parent.part.pdg_code() << " " << parent.part.creation_process() << std::endl;
+              break;
+            }
+            parent_index_before = parent_index;
+            parent_index = ancestor_index;
+          }
+        }
+        // if parent is found, merge
+        if(parent_found) {
+          auto& parent = part_grp_v[parent_index];
+          parent.Merge(grp);
+          merge_ctr++;
+        }
       }
       LARCV_INFO() << "Ionization merge counter: " << merge_ctr << " invalid counter: " << invalid_ctr << std::endl;
     }while(merge_ctr>0);
@@ -729,26 +708,24 @@ namespace larcv {
       dedx.reserve(grp.dedx.size());
       bool fill_dedx = grp.dedx.size();
       for(size_t i=0; i<grp.vs.size(); ++i) {
-	auto const& vox_energy = grp.vs.as_vector()[i];
-	if(vox_energy.value() < _edep_threshold) continue;
-	vs.emplace(vox_energy.id(),vox_energy.value(),true);
-	if(!fill_dedx) continue;
-	auto const& vox_dedx = grp.dedx.as_vector()[i];
-	if(vox_dedx.id() != vox_energy.id()) {
-	  LARCV_CRITICAL() << "Unmatched voxel ID between dE/dX and energy voxels" << std::endl;
-	  throw larbys();
-	}
-	dedx.emplace(vox_dedx.id(),vox_dedx.value(),true);
+        auto const& vox_energy = grp.vs.as_vector()[i];
+        if(vox_energy.value() < _edep_threshold) continue;
+        vs.emplace(vox_energy.id(),vox_energy.value(),true);
+        if(!fill_dedx) continue;
+        auto const& vox_dedx = grp.dedx.as_vector()[i];
+        if(vox_dedx.id() != vox_energy.id()) {
+          LARCV_CRITICAL() << "Unmatched voxel ID between dE/dX and energy voxels" << std::endl;
+          throw larbys();
+        }
+        dedx.emplace(vox_dedx.id(),vox_dedx.value(),true);
       }
       grp.vs = vs;
       grp.dedx = dedx;
       // If compton, here decide whether it should be supera::kComptonHE (high energy)
       if(grp.type == supera::kCompton && grp.vs.size() > _compton_size) {
-	//std::cout<<"Track ID "<<grp.part.track_id()<<" high energy compton"<<std::endl;
         grp.type = supera::kComptonHE;
       }
       else if(grp.type == supera::kOtherShower && grp.vs.size() > _compton_size) {
-	//std::cout<<"Track ID "<<grp.part.track_id()<<" high energy compton"<<std::endl;
         grp.type = supera::kOtherShowerHE;
       }
     }
@@ -762,49 +739,49 @@ namespace larcv {
     do {
       merge_ctr = 0;
       for(auto& grp : part_grp_v) {
-	if(!grp.valid) continue;
-	//if(grp.type != supera::kIonization && grp.type != supera::kConversion) continue;
-	if(grp.type != supera::kConversion) continue;
-	// merge to a valid "parent"
-	bool parent_found = false;
-	int parent_index = grp.part.parent_track_id();
-	int parent_index_before = grp.part.track_id();
-	while(1) {
-	  //std::cout<< "Inspecting: " << grp.part.track_id() << " => " << parent_index << std::endl;
-	  if(parent_index <0) {
-	    LARCV_DEBUG() << "Invalid parent track id " << parent_index
-			  << " Could not find a parent for " << grp.part.track_id() << " PDG " << grp.part.pdg_code()
-			  << " " << grp.part.creation_process() << " E = " << grp.part.energy_init()
-			  << " (" << grp.part.energy_deposit() << ") MeV" << std::endl;
-	    auto const& parent = part_grp_v[parent_index_before].part;
-	    LARCV_DEBUG() << "Previous parent: " << parent.track_id() << " PDG " << parent.pdg_code()
-			  << " " << parent.creation_process()
-			  << std::endl;
-	    parent_found=false;
-	    invalid_ctr++;
-	    break;
-	    //throw std::exception();
-	  }
-	  auto const& parent = part_grp_v[parent_index];
-	  parent_found = parent.valid;
-	  if(parent_found) break;
-	  else{
-	    int ancestor_index = parent.part.parent_track_id();
-	    if(ancestor_index == parent_index) {
-	      LARCV_INFO() << "Particle " << parent_index << " is root and invalid particle..." << std::endl
-			   << "PDG " << parent.part.pdg_code() << " " << parent.part.creation_process() << std::endl;
-	      break;
-	    }
-	    parent_index_before = parent_index;
-	    parent_index = ancestor_index;
-	  }
-	}
-	// if parent is found, merge
-	if(parent_found) {
-	  auto& parent = part_grp_v[parent_index];
-	  parent.Merge(grp);
-	  merge_ctr++;
-	}
+        if(!grp.valid) continue;
+        //if(grp.type != supera::kIonization && grp.type != supera::kConversion) continue;
+        if(grp.type != supera::kConversion) continue;
+        // merge to a valid "parent"
+        bool parent_found = false;
+        int parent_index = grp.part.parent_track_id();
+        int parent_index_before = grp.part.track_id();
+        while(1) {
+          //std::cout<< "Inspecting: " << grp.part.track_id() << " => " << parent_index << std::endl;
+          if(parent_index <0) {
+            LARCV_DEBUG() << "Invalid parent track id " << parent_index
+              << " Could not find a parent for " << grp.part.track_id() << " PDG " << grp.part.pdg_code()
+              << " " << grp.part.creation_process() << " E = " << grp.part.energy_init()
+              << " (" << grp.part.energy_deposit() << ") MeV" << std::endl;
+            auto const& parent = part_grp_v[parent_index_before].part;
+            LARCV_DEBUG() << "Previous parent: " << parent.track_id() << " PDG " << parent.pdg_code()
+              << " " << parent.creation_process()
+              << std::endl;
+            parent_found=false;
+            invalid_ctr++;
+            break;
+            //throw std::exception();
+          }
+          auto const& parent = part_grp_v[parent_index];
+          parent_found = parent.valid;
+          if(parent_found) break;
+          else{
+            int ancestor_index = parent.part.parent_track_id();
+            if(ancestor_index == parent_index) {
+              LARCV_INFO() << "Particle " << parent_index << " is root and invalid particle..." << std::endl
+               << "PDG " << parent.part.pdg_code() << " " << parent.part.creation_process() << std::endl;
+              break;
+            }
+            parent_index_before = parent_index;
+            parent_index = ancestor_index;
+          }
+        }
+        // if parent is found, merge
+        if(parent_found) {
+          auto& parent = part_grp_v[parent_index];
+          parent.Merge(grp);
+          merge_ctr++;
+        }
       }
       LARCV_INFO() << "Merge counter: " << merge_ctr << " invalid counter: " << invalid_ctr << std::endl;
     }while(merge_ctr>0);
@@ -812,7 +789,7 @@ namespace larcv {
 
 
   void SuperaMCParticleCluster::MergeShowerFamilyTouching(const larcv::Voxel3DMeta& meta,
-							  std::vector<supera::ParticleGroup>& part_grp_v)
+                std::vector<supera::ParticleGroup>& part_grp_v)
   {
     // Merge touching shower fragments
     // Direct parentage between kShapeShower => kShapeShower/kShapeDelta/kShapeMichel
@@ -821,35 +798,35 @@ namespace larcv {
     do {
       merge_ctr = 0;
       for(auto& grp : part_grp_v) {
-	if(!grp.valid) continue;
-	if(grp.shape() != larcv::kShapeShower) continue;
-	// search for a possible parent
-	int parent_trackid = -1;
-	// a direct parent ?
-	if(part_grp_v[grp.part.parent_track_id()].valid)
-	  parent_trackid = grp.part.parent_track_id();
-	else {
-	  for(size_t shower_trackid = 0; shower_trackid<part_grp_v.size(); ++shower_trackid) {
-	    auto const& candidate_grp = part_grp_v[shower_trackid];
-	    if(shower_trackid == grp.part.parent_track_id() || !candidate_grp.valid) continue;
-	    for(auto const& trackid : candidate_grp.trackid_v) {
-	      if(trackid != grp.part.parent_track_id()) continue;
-	      parent_trackid = shower_trackid;
-	      break;
-	    }
-	    if(parent_trackid >= 0) break;
-	  }
-	}
-	if(parent_trackid < 0 || parent_trackid == (int)(grp.part.track_id())) continue;
-	auto& parent = part_grp_v[parent_trackid];
-	//auto parent_type = part_grp_v[parent_trackid].type;
-	//if(parent_type == supera::kTrack || parent_type == supera::kNeutron) continue;
-	if(parent.shape() != larcv::kShapeShower && parent.shape() != larcv::kShapeDelta && parent.shape() != larcv::kShapeMichel) continue;
-	if(this->IsTouching(meta,grp.vs,parent.vs)) {
-	  // if parent is found, merge
-	  parent.Merge(grp);
-	  merge_ctr++;
-	}
+        if(!grp.valid) continue;
+        if(grp.shape() != larcv::kShapeShower) continue;
+        // search for a possible parent
+        int parent_trackid = -1;
+        // a direct parent ?
+        if(part_grp_v[grp.part.parent_track_id()].valid)
+          parent_trackid = grp.part.parent_track_id();
+        else {
+          for(size_t shower_trackid = 0; shower_trackid<part_grp_v.size(); ++shower_trackid) {
+            auto const& candidate_grp = part_grp_v[shower_trackid];
+            if(shower_trackid == grp.part.parent_track_id() || !candidate_grp.valid) continue;
+            for(auto const& trackid : candidate_grp.trackid_v) {
+              if(trackid != grp.part.parent_track_id()) continue;
+              parent_trackid = shower_trackid;
+              break;
+            }
+            if(parent_trackid >= 0) break;
+          }
+        }
+        if(parent_trackid < 0 || parent_trackid == (int)(grp.part.track_id())) continue;
+        auto& parent = part_grp_v[parent_trackid];
+        //auto parent_type = part_grp_v[parent_trackid].type;
+        //if(parent_type == supera::kTrack || parent_type == supera::kNeutron) continue;
+        if(parent.shape() != larcv::kShapeShower && parent.shape() != larcv::kShapeDelta && parent.shape() != larcv::kShapeMichel) continue;
+        if(this->IsTouching(meta,grp.vs,parent.vs)) {
+          // if parent is found, merge
+          parent.Merge(grp);
+          merge_ctr++;
+        }
       }
       LARCV_INFO() << "Merge counter: " << merge_ctr << " invalid counter: " << invalid_ctr << std::endl;
     }while(merge_ctr>0);
@@ -857,7 +834,7 @@ namespace larcv {
 
 
   void SuperaMCParticleCluster::MergeShowerTouching(const larcv::Voxel3DMeta& meta,
-						    std::vector<supera::ParticleGroup>& part_grp_v)
+                std::vector<supera::ParticleGroup>& part_grp_v)
   {
     // Go over all pair-wise combination of two shower instances
     // For each shower, find all consecutive parents of shower/michel/delta type (break if track found)
@@ -866,88 +843,88 @@ namespace larcv {
     do {
       merge_ctr = 0;
       for(size_t i=0; i<part_grp_v.size(); ++i) {
-	auto& grp_a = part_grp_v[i];
-	if(!grp_a.valid) continue;
-	if(grp_a.shape() != larcv::kShapeShower) continue;
-	for(size_t j=i; j<part_grp_v.size(); ++j) {
-	  if(i==j) continue;
-	  auto& grp_b = part_grp_v[j];
-	  if(!grp_b.valid) continue;
-	  if(grp_b.shape() != larcv::kShapeShower) continue;
+        auto& grp_a = part_grp_v[i];
+        if(!grp_a.valid) continue;
+        if(grp_a.shape() != larcv::kShapeShower) continue;
+        for(size_t j=i; j<part_grp_v.size(); ++j) {
+          if(i==j) continue;
+          auto& grp_b = part_grp_v[j];
+          if(!grp_b.valid) continue;
+          if(grp_b.shape() != larcv::kShapeShower) continue;
 
-	  // check if these showers share the parentage
-	  // list a's parents
-	  size_t trackid=i;
-	  std::set<size_t> parent_list_a;
-	  std::set<size_t> parent_list_b;
-	  /*
-	  while(1){
-	    auto const& parent_a = part_grp_v[trackid];
-	    if(parent_a.part.parent_track_id() >= part_grp_v.size())
-	      break;
-	    if(parent_a.part.parent_track_id() == parent_a.part.track_id())
-	      break;
-	    trackid = parent_a.part.parent_track_id();
-	    if(parent_a.shape() == larcv::kShapeMichel ||
-	       parent_a.shape() == larcv::kShapeShower ||
-	       parent_a.shape() == larcv::kShapeDelta )
-	      parent_list_a.insert(trackid);
-	    else if(parent_a.shape() == larcv::kShapeTrack ||
-		    parent_a.shape() == larcv::kShapeUnknown)
-	      break;
+          // check if these showers share the parentage
+          // list a's parents
+          size_t trackid=i;
+          std::set<size_t> parent_list_a;
+          std::set<size_t> parent_list_b;
+          /*
+          while(1){
+            auto const& parent_a = part_grp_v[trackid];
+            if(parent_a.part.parent_track_id() >= part_grp_v.size())
+              break;
+            if(parent_a.part.parent_track_id() == parent_a.part.track_id())
+              break;
+            trackid = parent_a.part.parent_track_id();
+            if(parent_a.shape() == larcv::kShapeMichel ||
+               parent_a.shape() == larcv::kShapeShower ||
+               parent_a.shape() == larcv::kShapeDelta )
+              parent_list_a.insert(trackid);
+            else if(parent_a.shape() == larcv::kShapeTrack ||
+              parent_a.shape() == larcv::kShapeUnknown)
+              break;
 
-	    if(trackid < part_grp_v.size() && part_grp_v[trackid].part.parent_track_id() == trackid)
-	      break;
-	  }
-	  */
-	  auto parents_a = this->ParentShowerTrackIDs(trackid,part_grp_v);
-	  for(auto const& parent_trackid : parents_a) parent_list_a.insert(parent_trackid);
-	  parent_list_a.insert(trackid);
+            if(trackid < part_grp_v.size() && part_grp_v[trackid].part.parent_track_id() == trackid)
+              break;
+          }
+          */
+          auto parents_a = this->ParentShowerTrackIDs(trackid,part_grp_v);
+          for(auto const& parent_trackid : parents_a) parent_list_a.insert(parent_trackid);
+          parent_list_a.insert(trackid);
 
-	  trackid=j;
-	  /*
-	  while(1){
-	    auto const& parent_b = part_grp_v[trackid];
-	    if(parent_b.part.parent_track_id() >= part_grp_v.size())
-	      break;
-	    if(parent_b.part.parent_track_id() == parent_b.part.track_id())
-	      break;
-	    trackid = parent_b.part.parent_track_id();
-	    if(parent_b.shape() == larcv::kShapeMichel ||
-	       parent_b.shape() == larcv::kShapeShower ||
-	       parent_b.shape() == larcv::kShapeDelta )
-	      parent_list_b.insert(trackid);
-	    else if(parent_b.shape() == larcv::kShapeTrack ||
-		    parent_b.shape() == larcv::kShapeUnknown)
-	      break;
-	    if(trackid < part_grp_v.size() && part_grp_v[trackid].part.parent_track_id() == trackid)
-	      break;
-	  }
-	  */
-	  auto parents_b = this->ParentShowerTrackIDs(trackid,part_grp_v);
-	  for(auto const& parent_trackid : parents_b) parent_list_b.insert(parent_trackid);
-	  parent_list_b.insert(trackid);
+          trackid=j;
+          /*
+          while(1){
+            auto const& parent_b = part_grp_v[trackid];
+            if(parent_b.part.parent_track_id() >= part_grp_v.size())
+              break;
+            if(parent_b.part.parent_track_id() == parent_b.part.track_id())
+              break;
+            trackid = parent_b.part.parent_track_id();
+            if(parent_b.shape() == larcv::kShapeMichel ||
+               parent_b.shape() == larcv::kShapeShower ||
+               parent_b.shape() == larcv::kShapeDelta )
+              parent_list_b.insert(trackid);
+            else if(parent_b.shape() == larcv::kShapeTrack ||
+              parent_b.shape() == larcv::kShapeUnknown)
+              break;
+            if(trackid < part_grp_v.size() && part_grp_v[trackid].part.parent_track_id() == trackid)
+              break;
+          }
+          */
+          auto parents_b = this->ParentShowerTrackIDs(trackid,part_grp_v);
+          for(auto const& parent_trackid : parents_b) parent_list_b.insert(parent_trackid);
+          parent_list_b.insert(trackid);
 
-	  bool merge=false;
-	  for(auto const& parent_trackid : parent_list_a) {
-	    if(parent_list_b.find(parent_trackid) != parent_list_b.end())
-	      merge=true;
-	    if(merge) break;
-	  }
-	  for(auto const& parent_trackid : parent_list_b) {
-	    if(parent_list_a.find(parent_trackid) != parent_list_a.end())
-	      merge=true;
-	    if(merge) break;
-	  }
+          bool merge=false;
+          for(auto const& parent_trackid : parent_list_a) {
+            if(parent_list_b.find(parent_trackid) != parent_list_b.end())
+              merge=true;
+            if(merge) break;
+          }
+          for(auto const& parent_trackid : parent_list_b) {
+            if(parent_list_a.find(parent_trackid) != parent_list_a.end())
+              merge=true;
+            if(merge) break;
+          }
 
-	  if(merge && this->IsTouching(meta,grp_a.vs,grp_b.vs)) {
-	    if(grp_a.vs.size() < grp_b.vs.size())
-	      grp_b.Merge(grp_a);
-	    else
-	      grp_a.Merge(grp_b);
-	    merge_ctr++;
-	  }
-	}
+          if(merge && this->IsTouching(meta,grp_a.vs,grp_b.vs)) {
+            if(grp_a.vs.size() < grp_b.vs.size())
+              grp_b.Merge(grp_a);
+            else
+              grp_a.Merge(grp_b);
+            merge_ctr++;
+          }
+        }
       }
       LARCV_INFO() << "Merge counter: " << merge_ctr << std::endl;
     }while(merge_ctr>0);
@@ -963,66 +940,66 @@ namespace larcv {
       auto const& meta = _meta2d_v[plane];
       size_t vox2d_ctr=0;
       for(size_t i=0; i<part_grp_v.size(); ++i) {
-	children_v[i] = part_grp_v[i].trackid_v;
-	valid_v[i]    = part_grp_v[i].valid;
-	if(part_grp_v[i].vs2d_v.size() > plane)
-	  vox2d_ctr    += part_grp_v[i].vs2d_v.at(plane).size();
-      }
-      if(vox2d_ctr<1) continue;
+        children_v[i] = part_grp_v[i].trackid_v;
+        valid_v[i]    = part_grp_v[i].valid;
+        if(part_grp_v[i].vs2d_v.size() > plane)
+          vox2d_ctr    += part_grp_v[i].vs2d_v.at(plane).size();
+            }
+            if(vox2d_ctr<1) continue;
 
-      int merge_ctr = 0;
-      int invalid_ctr = 0;
-      do {
-	merge_ctr = 0;
-	for(size_t part_idx=0; part_idx<part_grp_v.size(); ++part_idx) {
-	  auto& grp = part_grp_v[part_idx];
-	  if(valid_v[part_idx]) continue;
-	  if(plane >= grp.vs2d_v.size()) continue;
-	  if(grp.vs2d_v[plane].size()<1) continue;
-	  //if(grp.type == supera::kTrack || grp.type == supera::kNeutron || grp.type == supera::kDelta || grp.type == supera::kDecay) continue;
-	  if(grp.shape() != larcv::kShapeShower) continue;
-	  // search for a possible parent
-	  int parent_trackid = -1;
-	  // a direct parent ?
-	  if(valid_v[grp.part.parent_track_id()])
-	    parent_trackid = grp.part.parent_track_id();
-	  else {
-	    for(size_t shower_trackid = 0; shower_trackid<part_grp_v.size(); ++shower_trackid) {
-	      if(shower_trackid == grp.part.parent_track_id() || !valid_v[shower_trackid]) continue;
-	      for(auto const& trackid : children_v[shower_trackid]) {
-		if(trackid != grp.part.parent_track_id()) continue;
-		parent_trackid = shower_trackid;
-		break;
-	      }
-	      if(parent_trackid >= 0) break;
-	    }
-	  }
-	  if(parent_trackid < 0 || parent_trackid == (int)(grp.part.track_id())) continue;
-	  auto& parent = part_grp_v[parent_trackid];
-	  auto parent_type = part_grp_v[parent_trackid].type;
-	  if(parent_type == supera::kTrack || parent_type == supera::kNeutron) continue;
-	  if(this->IsTouching2D(meta,grp.vs2d_v[plane],parent.vs2d_v[plane])) {
-	    // if parent is found, merge 2d voxels
+            int merge_ctr = 0;
+            int invalid_ctr = 0;
+            do {
+        merge_ctr = 0;
+        for(size_t part_idx=0; part_idx<part_grp_v.size(); ++part_idx) {
+          auto& grp = part_grp_v[part_idx];
+          if(valid_v[part_idx]) continue;
+          if(plane >= grp.vs2d_v.size()) continue;
+          if(grp.vs2d_v[plane].size()<1) continue;
+          //if(grp.type == supera::kTrack || grp.type == supera::kNeutron || grp.type == supera::kDelta || grp.type == supera::kDecay) continue;
+          if(grp.shape() != larcv::kShapeShower) continue;
+          // search for a possible parent
+          int parent_trackid = -1;
+          // a direct parent ?
+          if(valid_v[grp.part.parent_track_id()])
+            parent_trackid = grp.part.parent_track_id();
+          else {
+            for(size_t shower_trackid = 0; shower_trackid<part_grp_v.size(); ++shower_trackid) {
+              if(shower_trackid == grp.part.parent_track_id() || !valid_v[shower_trackid]) continue;
+              for(auto const& trackid : children_v[shower_trackid]) {
+          if(trackid != grp.part.parent_track_id()) continue;
+          parent_trackid = shower_trackid;
+          break;
+              }
+              if(parent_trackid >= 0) break;
+            }
+          }
+          if(parent_trackid < 0 || parent_trackid == (int)(grp.part.track_id())) continue;
+          auto& parent = part_grp_v[parent_trackid];
+          auto parent_type = part_grp_v[parent_trackid].type;
+          if(parent_type == supera::kTrack || parent_type == supera::kNeutron) continue;
+          if(this->IsTouching2D(meta,grp.vs2d_v[plane],parent.vs2d_v[plane])) {
+            // if parent is found, merge 2d voxels
 
-	    valid_v[grp.part.track_id()] = false;
-	    children_v[parent_trackid].push_back(grp.part.track_id());
-	    for(auto const& trackid : children_v[grp.part.track_id()])
-	      children_v[parent_trackid].push_back(trackid);
-	    children_v[part_idx].clear();
-	    // merge 2D voxels
-	    for(auto const& vox : grp.vs2d_v[plane].as_vector())
-	      parent.vs2d_v[plane].emplace(vox.id(),vox.value(),true);
-	    grp.vs2d_v[plane].clear_data();
-	    merge_ctr++;
-	    /*
-	    std::cout<<"Track " << grp.part.track_id() << " PDG " << grp.part.pdg_code() << " " << grp.part.creation_process()
-		     <<" ... parent found " << parent.part.track_id() << " PDG " << parent.part.pdg_code() << " " << parent.part.creation_process()
-		     << std::endl;
-	    */
-	  }
-	}
-	LARCV_INFO() << "Merge counter: " << merge_ctr << " invalid counter: " << invalid_ctr << std::endl;
-      }while(merge_ctr>0);
+            valid_v[grp.part.track_id()] = false;
+            children_v[parent_trackid].push_back(grp.part.track_id());
+            for(auto const& trackid : children_v[grp.part.track_id()])
+              children_v[parent_trackid].push_back(trackid);
+            children_v[part_idx].clear();
+            // merge 2D voxels
+            for(auto const& vox : grp.vs2d_v[plane].as_vector())
+              parent.vs2d_v[plane].emplace(vox.id(),vox.value(),true);
+            grp.vs2d_v[plane].clear_data();
+            merge_ctr++;
+            /*
+            std::cout<<"Track " << grp.part.track_id() << " PDG " << grp.part.pdg_code() << " " << grp.part.creation_process()
+               <<" ... parent found " << parent.part.track_id() << " PDG " << parent.part.pdg_code() << " " << parent.part.creation_process()
+               << std::endl;
+            */
+          }
+        }
+        LARCV_INFO() << "Merge counter: " << merge_ctr << " invalid counter: " << invalid_ctr << std::endl;
+            }while(merge_ctr>0);
     }
   }
 
@@ -1038,88 +1015,88 @@ namespace larcv {
 
       // if voxel count is smaller than delta ray requirement, simply merge
       if(grp.vs.size() < _delta_size) {
-	// if parent is found, merge
-	/*
-	if(grp.vs.size()>0) {
-	  std::cout<<"Merging delta " << grp.part.track_id() << " PDG " << grp.part.pdg_code()
-		   << " " << grp.part.creation_process() << " vox count " << grp.vs.size() << std::endl
-		   <<" ... parent found " << parent.part.track_id()
-		   << " PDG " << parent.part.pdg_code() << " " << parent.part.creation_process()
-		   << std::endl;
-	  for(auto const& vs : grp.vs2d_v)
-	    std::cout<<vs.size() << " " << std::flush;
-	  std::cout<<std::endl;
-	}
-	*/
-	parent.Merge(grp);
-      }else{
-	// check unique number of voxels
-	size_t unique_voxel_count = 0;
-	for(auto const& vox : grp.vs.as_vector()) {
-	  if(parent.vs.find(vox.id()).id() == larcv::kINVALID_VOXELID)
-	    ++unique_voxel_count;
-	}
-	if(unique_voxel_count < _delta_size) {
-	  // if parent is found, merge
-	  /*
-	  if(unique_voxel_count>0) {
-	    std::cout<<"Merging delta " << grp.part.track_id() << " PDG " << grp.part.pdg_code()
-		     << " " << grp.part.creation_process() << " vox count " << grp.vs.size() << std::endl
-		     <<" ... parent found " << parent.part.track_id()
-		     << " PDG " << parent.part.pdg_code() << " " << parent.part.creation_process()
-		     << std::endl;
-	    for(auto const& vs : grp.vs2d_v)
-	      std::cout<<vs.size() << " " << std::flush;
-	    std::cout<<std::endl;
-	  }
-	  */
-	  parent.Merge(grp);
-	}
-	/*
-	else{
-	  std::cout<<"NOT merging delta " << grp.part.track_id() << " PDG " << grp.part.pdg_code()
-		   << " " << grp.part.creation_process() << " vox count " << grp.vs.size() << std::endl
-		   <<" ... parent found " << parent.part.track_id()
-		   << " PDG " << parent.part.pdg_code() << " " << parent.part.creation_process()
-		   << std::endl;
-	  for(auto const& vs : grp.vs2d_v)
-	    std::cout<<vs.size() << " " << std::flush;
-	  std::cout<<std::endl;
+        // if parent is found, merge
+        /*
+        if(grp.vs.size()>0) {
+          std::cout<<"Merging delta " << grp.part.track_id() << " PDG " << grp.part.pdg_code()
+             << " " << grp.part.creation_process() << " vox count " << grp.vs.size() << std::endl
+             <<" ... parent found " << parent.part.track_id()
+             << " PDG " << parent.part.pdg_code() << " " << parent.part.creation_process()
+             << std::endl;
+          for(auto const& vs : grp.vs2d_v)
+            std::cout<<vs.size() << " " << std::flush;
+          std::cout<<std::endl;
+        }
+        */
+        parent.Merge(grp);
+            }else{
+        // check unique number of voxels
+        size_t unique_voxel_count = 0;
+        for(auto const& vox : grp.vs.as_vector()) {
+          if(parent.vs.find(vox.id()).id() == larcv::kINVALID_VOXELID)
+            ++unique_voxel_count;
+        }
+        if(unique_voxel_count < _delta_size) {
+          // if parent is found, merge
+          /*
+          if(unique_voxel_count>0) {
+            std::cout<<"Merging delta " << grp.part.track_id() << " PDG " << grp.part.pdg_code()
+               << " " << grp.part.creation_process() << " vox count " << grp.vs.size() << std::endl
+               <<" ... parent found " << parent.part.track_id()
+               << " PDG " << parent.part.pdg_code() << " " << parent.part.creation_process()
+               << std::endl;
+            for(auto const& vs : grp.vs2d_v)
+              std::cout<<vs.size() << " " << std::flush;
+            std::cout<<std::endl;
+          }
+          */
+          parent.Merge(grp);
+        }
+        /*
+        else{
+          std::cout<<"NOT merging delta " << grp.part.track_id() << " PDG " << grp.part.pdg_code()
+             << " " << grp.part.creation_process() << " vox count " << grp.vs.size() << std::endl
+             <<" ... parent found " << parent.part.track_id()
+             << " PDG " << parent.part.pdg_code() << " " << parent.part.creation_process()
+             << std::endl;
+          for(auto const& vs : grp.vs2d_v)
+            std::cout<<vs.size() << " " << std::flush;
+          std::cout<<std::endl;
 
-	}
-	*/
+        }
+        */
       }
     }
   }
 
   void SuperaMCParticleCluster::MergeShowerTouchingLEScatter(const larcv::Voxel3DMeta& meta,
-							     std::vector<supera::ParticleGroup>& part_grp_v)
+                   std::vector<supera::ParticleGroup>& part_grp_v)
   {
     size_t merge_ctr=1;
     while(merge_ctr) {
       merge_ctr = 0;
       for(auto& grp : part_grp_v) {
-	if(!grp.valid || grp.vs.size()<1 || grp.shape() != larcv::kShapeLEScatter) continue;
-	// Find all direct shower-type or other LEScatter type parent
-	//auto const& parents = this->ParentShowerTrackIDs(grp.part.track_id(), part_grp_v, true);
-	auto const& parents = this->ParentTrackIDs(grp.part.track_id());
-	/*
-	std::cout<<"Inspecting LEScatter Track ID " << grp.part.track_id()
-		 << " PDG " << grp.part.pdg_code()
-		 << " " << grp.part.creation_process() << std::endl;
-	std::cout<< "  ... parents:"<<std::flush;
-	for(auto const& parent_trackid : parents) std::cout<<" "<<parent_trackid;
-	std::cout<<std::endl;
-	*/
-	for(auto const& parent_trackid : parents) {
-	  auto& parent = part_grp_v[parent_trackid];
-	  if(!parent.valid || parent.vs.size()<1) continue;
-	  if(this->IsTouching(meta,grp.vs,parent.vs)) {
-	    parent.Merge(grp);
-	    merge_ctr++;
-	    break;
-	  }
-	}
+        if(!grp.valid || grp.vs.size()<1 || grp.shape() != larcv::kShapeLEScatter) continue;
+        // Find all direct shower-type or other LEScatter type parent
+        //auto const& parents = this->ParentShowerTrackIDs(grp.part.track_id(), part_grp_v, true);
+        auto const& parents = this->ParentTrackIDs(grp.part.track_id());
+        /*
+        std::cout<<"Inspecting LEScatter Track ID " << grp.part.track_id()
+           << " PDG " << grp.part.pdg_code()
+           << " " << grp.part.creation_process() << std::endl;
+        std::cout<< "  ... parents:"<<std::flush;
+        for(auto const& parent_trackid : parents) std::cout<<" "<<parent_trackid;
+        std::cout<<std::endl;
+        */
+        for(auto const& parent_trackid : parents) {
+          auto& parent = part_grp_v[parent_trackid];
+          if(!parent.valid || parent.vs.size()<1) continue;
+          if(this->IsTouching(meta,grp.vs,parent.vs)) {
+            parent.Merge(grp);
+            merge_ctr++;
+            break;
+          }
+        }
       }
     }
   }
@@ -1149,24 +1126,24 @@ namespace larcv {
     _meta2d_v.resize(_valid_nplanes);
     for(size_t cryo_id=0; cryo_id < _scan.size(); cryo_id++) {
       for(size_t tpc_id=0; tpc_id < _scan[cryo_id].size(); tpc_id++) {
-	for(size_t plane_id=0; plane_id < _scan[cryo_id][tpc_id].size(); ++plane_id) {
-	  auto meta2d_idx = _scan[cryo_id][tpc_id][plane_id];
-	  if(meta2d_idx < 0) continue;
-	  std::string product_name = _ref_meta2d_tensor2d + "_";
-	  product_name = product_name + std::to_string(cryo_id) + "_" + std::to_string(tpc_id) + "_" + std::to_string(plane_id);
-	  larcv::ProducerName_t product_id("sparse2d",product_name);
-	  if(mgr.producer_id(product_id) == larcv::kINVALID_PRODUCER) {
-	    LARCV_CRITICAL() << "Could not find tensor2d with a name: " << product_name << std::endl;
-	    throw larbys();
-	  }
-	  _meta2d_v[meta2d_idx] = mgr.get_data<larcv::EventSparseTensor2D>(product_name).as_vector().front().meta();
-	}
+        for(size_t plane_id=0; plane_id < _scan[cryo_id][tpc_id].size(); ++plane_id) {
+          auto meta2d_idx = _scan[cryo_id][tpc_id][plane_id];
+          if(meta2d_idx < 0) continue;
+          std::string product_name = _ref_meta2d_tensor2d + "_";
+          product_name = product_name + std::to_string(cryo_id) + "_" + std::to_string(tpc_id) + "_" + std::to_string(plane_id);
+          larcv::ProducerName_t product_id("sparse2d",product_name);
+          if(mgr.producer_id(product_id) == larcv::kINVALID_PRODUCER) {
+            LARCV_CRITICAL() << "Could not find tensor2d with a name: " << product_name << std::endl;
+            throw larbys();
+          }
+          _meta2d_v[meta2d_idx] = mgr.get_data<larcv::EventSparseTensor2D>(product_name).as_vector().front().meta();
+        }
       }
     }
 
     // Build MCParticle List
     auto const& larmcp_v = LArData<supera::LArMCParticle_t>();
-		std::cout << "larmcp_v size = " << larmcp_v.size() << std::endl;
+    std::cout << "larmcp_v size = " << larmcp_v.size() << std::endl;
     auto const *ev = GetEvent();
     _mcpl.Update(larmcp_v,ev->id().run(),ev->id().event());
 
@@ -1179,29 +1156,29 @@ namespace larcv {
     LARCV_INFO() << "Analyzing SimChannel/SimEnergyDeposit" << std::endl;
     if(_use_sed) {
       if (_use_sed_lite) {
-				this->AnalyzeSimEnergyDeposit<supera::LArSimEnergyDepositLite_t>(meta3d, part_grp_v, mgr);
-			} else {
-				this->AnalyzeSimEnergyDeposit<supera::LArSimEnergyDeposit_t>(meta3d, part_grp_v, mgr);
-			}
-		} else {
+        this->AnalyzeSimEnergyDeposit<supera::LArSimEnergyDepositLite_t>(meta3d, part_grp_v, mgr);
+      } else {
+        this->AnalyzeSimEnergyDeposit<supera::LArSimEnergyDeposit_t>(meta3d, part_grp_v, mgr);
+      }
+    } else {
       this->AnalyzeSimChannel(meta3d, part_grp_v, mgr);
-		}
+    }
     // Define particle first/last points based on SED
     LARCV_INFO() << "Analyzing First Step" << std::endl;
     if(_use_sed_points && !_use_sed) {
-			if (_use_sed_lite) {
-				this->AnalyzeFirstLastStep<supera::LArSimEnergyDepositLite_t>(meta3d, part_grp_v);
-			}else {
-				this->AnalyzeFirstLastStep<supera::LArSimEnergyDeposit_t>(meta3d, part_grp_v);
-			}
-		}
+      if (_use_sed_lite) {
+        this->AnalyzeFirstLastStep<supera::LArSimEnergyDepositLite_t>(meta3d, part_grp_v);
+      }else {
+        this->AnalyzeFirstLastStep<supera::LArSimEnergyDeposit_t>(meta3d, part_grp_v);
+      }
+    }
     /*
     std::cout<< "Listing non-zero voxel particles..." << std::endl;
     for(auto const& grp : part_grp_v) {
       if(grp.vs.size() < 1) continue;
       std::cout<<"Track ID " << grp.part.track_id() << " PDG " << grp.part.pdg_code()
-	       << " " << grp.part.creation_process() << " " << grp.vs.size() << " voxels"
-	       <<" ... parent Track ID " << grp.part.parent_track_id() << " PDG " << grp.part.parent_pdg_code() << std::endl;
+         << " " << grp.part.creation_process() << " " << grp.vs.size() << " voxels"
+         <<" ... parent Track ID " << grp.part.parent_track_id() << " PDG " << grp.part.parent_pdg_code() << std::endl;
     }
     */
 
@@ -1248,8 +1225,8 @@ namespace larcv {
     for(auto const& grp : part_grp_v) {
       if(grp.vs.size() < 1) continue;
       std::cout<<"Track ID " << grp.part.track_id() << " PDG " << grp.part.pdg_code()
-	       << " " << grp.part.creation_process() << " " << grp.vs.size() << " voxels"
-	       <<" ... parent Track ID " << grp.part.parent_track_id() << " PDG " << grp.part.parent_pdg_code() << std::endl;
+         << " " << grp.part.creation_process() << " " << grp.vs.size() << " voxels"
+         <<" ... parent Track ID " << grp.part.parent_track_id() << " PDG " << grp.part.parent_pdg_code() << std::endl;
     }
     */
     // Assign output IDs
@@ -1257,29 +1234,37 @@ namespace larcv {
     std::set<unsigned int> mcs_trackid_s;
     auto const& mcs_v = LArData<supera::LArMCShower_t>();
     for(auto const& mcs : mcs_v) {mcs_trackid_s.insert(mcs.TrackID());}
+    for(auto const& mcs : mcs_v) {std::cout << "MCShower " << mcs.TrackID() << std::endl;}
     std::vector<int> trackid2output(trackid2index.size(),-1);
     std::vector<int> output2trackid;
     output2trackid.reserve(trackid2index.size());
+    std::cout << "Filling output2trackid - part_grp_v size = " << part_grp_v.size() << std::endl;
     for(size_t trackid=0; trackid<part_grp_v.size(); trackid++) {
       auto& grp = part_grp_v[trackid];
       grp.part.energy_deposit((grp.vs.size() ? grp.vs.sum() : 0.));
       size_t output_counter = output2trackid.size();
       if(mcs_trackid_s.find(trackid) != mcs_trackid_s.end()){
-	grp.valid=true;
-	grp.part.group_id(output_counter);
+        std::cout << "adding " << trackid << std::endl;
+        grp.valid=true;
+        grp.part.group_id(output_counter);
       }
       else{
-	if(!grp.valid) continue;
-	if(grp.size_all()<1) continue;
-	if(grp.shape() == larcv::kShapeLEScatter) continue;
+        if ((grp.part.track_id() == 32330) || (grp.part.track_id() == 32407)) std::cout << grp.part.track_id() << " " << grp.valid << " " << grp.size_all() << " " << grp.shape() << " " << larcv::kShapeLEScatter << std::endl;
+        if(!grp.valid) continue;
+        if(grp.size_all()<1) continue;
+        if(grp.shape() == larcv::kShapeLEScatter) continue;
       }
 
+      //std::cout << grp.shape() << " " << grp.size_all() << std::endl;
+      //std::cout << grp.part.track_id() << larcv::kINVALID_UINT << std::endl;
+      if (grp.part.track_id() == larcv::kINVALID_UINT) continue;
       grp.part.id(output_counter);
       trackid2output[grp.part.track_id()] = output_counter;
       for(auto const& child : grp.trackid_v)
-	trackid2output[child] = output_counter;
+        trackid2output[child] = output_counter;
       output2trackid.push_back(grp.part.track_id());
       ++output_counter;
+      std::cout << "Added to output2trackid " << grp.part.track_id() << std::endl;
     }
 
 
@@ -1289,16 +1274,16 @@ namespace larcv {
       if( abs(grp.part.pdg_code()) != 11 && abs(grp.part.pdg_code()) != 22 ) continue;
       int parent_trackid = grp.part.parent_track_id();
       if(trackid2output[parent_trackid] >= 0) {
-      /*
-      if(trackid2output[parent_trackid] < 0)
-	grp.part.parent_id(grp.part.id());
-      else {
-      */
-	grp.part.parent_id(trackid2output[parent_trackid]);
-	int parent_output_id = trackid2output[parent_trackid];
-	int parent_id = output2trackid[parent_output_id];
-	if(part_grp_v[parent_id].valid)
-	  part_grp_v[parent_id].part.children_id(grp.part.id());
+            /*
+            if(trackid2output[parent_trackid] < 0)
+        grp.part.parent_id(grp.part.id());
+            else {
+            */
+        grp.part.parent_id(trackid2output[parent_trackid]);
+        int parent_output_id = trackid2output[parent_trackid];
+        int parent_id = output2trackid[parent_output_id];
+        if(part_grp_v[parent_id].valid)
+          part_grp_v[parent_id].part.children_id(grp.part.id());
       }
     }
 
@@ -1315,9 +1300,9 @@ namespace larcv {
       auto const& last_pt  = grp.last_pt;
       //std::cout<<first_pt.x<< " " << first_pt.y << " " << first_pt.z << std::endl;
       if(first_pt.t != larcv::kINVALID_DOUBLE)
-	part.first_step(first_pt.x,first_pt.y,first_pt.z,first_pt.t);
+        part.first_step(first_pt.x,first_pt.y,first_pt.z,first_pt.t);
       if(last_pt.t  != larcv::kINVALID_DOUBLE)
-	part.last_step(last_pt.x,last_pt.y,last_pt.z,last_pt.t);
+        part.last_step(last_pt.x,last_pt.y,last_pt.z,last_pt.t);
     }
 
 
@@ -1326,67 +1311,67 @@ namespace larcv {
     for(auto const& mcs : mcs_v) {
       int track_id = mcs.TrackID();
       if(track_id >= ((int)(trackid2output.size()))) {
-	LARCV_INFO() << "MCShower " << track_id << " PDG " << mcs.PdgCode()
-		     << " not found in output group..." << std::endl;
-	continue;
+        LARCV_INFO() << "MCShower " << track_id << " PDG " << mcs.PdgCode()
+               << " not found in output group..." << std::endl;
+        continue;
       }
       int output_id = trackid2output[track_id];
       //int group_id  = -1;
       int group_id  = output_id;
       if(output_id >= 0) {
-	auto& grp = part_grp_v[track_id];
-	assert(grp.part.group_id() == larcv::kINVALID_INSTANCEID);
-	grp.part.group_id(group_id);
-	/*
-	if(grp.part.group_id() == larcv::kINVALID_INSTANCEID) {
-	  if(group_id < 0) {
-	    group_id = group_counter + 1;
-	    ++group_counter;
-	  }
-	  grp.part.group_id(group_id);
-	}
-	*/
-	// see if first step is not set yet
-	if(grp.first_pt.t == larcv::kINVALID_DOUBLE)
-	  grp.part.first_step(mcs.DetProfile().X(),mcs.DetProfile().Y(),mcs.DetProfile().Z(),mcs.DetProfile().T());
-	grp.part.parent_position(mcs.MotherStart().X(),
-				 mcs.MotherStart().Y(),
-				 mcs.MotherStart().Z(),
-				 mcs.MotherStart().T());
-	grp.part.parent_creation_process(mcs.MotherProcess());
-	grp.part.ancestor_position(mcs.AncestorStart().X(),
-				   mcs.AncestorStart().Y(),
-				   mcs.AncestorStart().Z(),
-				   mcs.AncestorStart().T());
-	grp.part.ancestor_track_id(mcs.AncestorTrackID());
-	grp.part.ancestor_pdg_code(mcs.AncestorPdgCode());
-	grp.part.ancestor_creation_process(mcs.AncestorProcess());
+        auto& grp = part_grp_v[track_id];
+        assert(grp.part.group_id() == larcv::kINVALID_INSTANCEID);
+        grp.part.group_id(group_id);
+        /*
+        if(grp.part.group_id() == larcv::kINVALID_INSTANCEID) {
+          if(group_id < 0) {
+            group_id = group_counter + 1;
+            ++group_counter;
+          }
+          grp.part.group_id(group_id);
+        }
+        */
+        // see if first step is not set yet
+        if(grp.first_pt.t == larcv::kINVALID_DOUBLE)
+          grp.part.first_step(mcs.DetProfile().X(),mcs.DetProfile().Y(),mcs.DetProfile().Z(),mcs.DetProfile().T());
+        grp.part.parent_position(mcs.MotherStart().X(),
+               mcs.MotherStart().Y(),
+               mcs.MotherStart().Z(),
+               mcs.MotherStart().T());
+        grp.part.parent_creation_process(mcs.MotherProcess());
+        grp.part.ancestor_position(mcs.AncestorStart().X(),
+                 mcs.AncestorStart().Y(),
+                 mcs.AncestorStart().Z(),
+                 mcs.AncestorStart().T());
+        grp.part.ancestor_track_id(mcs.AncestorTrackID());
+        grp.part.ancestor_pdg_code(mcs.AncestorPdgCode());
+        grp.part.ancestor_creation_process(mcs.AncestorProcess());
       }
 
       for(auto const& child : mcs.DaughterTrackID()) {
-	//if(child < trackid2output.size() && trackid2output[child] < 0)
-	if(child < trackid2output.size() && trackid2output[child] >= 0) {
-	  trackid2output[child] = output_id;
-	  auto& grp = part_grp_v[child];
-	  assert(grp.part.group_id() == larcv::kINVALID_INSTANCEID);
-	  grp.part.group_id(group_id);
-	  /*
-	  if(grp.part.group_id() == larcv::kINVALID_INSTANCEID) {
-	    if(group_id < 0) {
-	      group_id = group_counter + 1;
-	      ++group_counter;
-	    }
-	    grp.part.group_id(group_id);
-	  }
-	  */
-	  grp.part.ancestor_position(mcs.AncestorStart().X(),
-				     mcs.AncestorStart().Y(),
-				     mcs.AncestorStart().Z(),
-				     mcs.AncestorStart().T());
-	  grp.part.ancestor_track_id(mcs.AncestorTrackID());
-	  grp.part.ancestor_pdg_code(mcs.AncestorPdgCode());
-	  grp.part.ancestor_creation_process(mcs.AncestorProcess());
-	}
+        //if(child < trackid2output.size() && trackid2output[child] < 0)
+        if(child < trackid2output.size() && trackid2output[child] >= 0) {
+          trackid2output[child] = output_id;
+          auto& grp = part_grp_v[child];
+          assert(grp.part.group_id() == larcv::kINVALID_INSTANCEID);
+          grp.part.group_id(group_id);
+          /*
+          if(grp.part.group_id() == larcv::kINVALID_INSTANCEID) {
+            if(group_id < 0) {
+              group_id = group_counter + 1;
+              ++group_counter;
+            }
+            grp.part.group_id(group_id);
+          }
+          */
+          grp.part.ancestor_position(mcs.AncestorStart().X(),
+                   mcs.AncestorStart().Y(),
+                   mcs.AncestorStart().Z(),
+                   mcs.AncestorStart().T());
+          grp.part.ancestor_track_id(mcs.AncestorTrackID());
+          grp.part.ancestor_pdg_code(mcs.AncestorPdgCode());
+          grp.part.ancestor_creation_process(mcs.AncestorProcess());
+        }
       }
     }
 
@@ -1400,51 +1385,51 @@ namespace larcv {
       //int group_id  = -1;
       int group_id  = output_id;
       if(output_id >= 0) {
-	auto& grp = part_grp_v[track_id];
-	assert(grp.part.group_id() == larcv::kINVALID_INSTANCEID);
-	/*
-	if(group_id < 0) {
-	  group_id = group_counter + 1;
-	  ++group_counter;
-	}
-	*/
-	grp.part.group_id(group_id);
-	if(grp.first_pt.t == larcv::kINVALID_DOUBLE && mct.size())
-	  grp.part.first_step(mct.front().X(),mct.front().Y(),mct.front().Z(),mct.front().T());
-	if(grp.last_pt.t == larcv::kINVALID_DOUBLE && mct.size())
-	  grp.part.last_step(mct.back().X(),mct.back().Y(),mct.back().Z(),mct.back().T());
-	grp.part.parent_position(mct.MotherStart().X(),
-				 mct.MotherStart().Y(),
-				 mct.MotherStart().Z(),
-				 mct.MotherStart().T());
-	grp.part.parent_creation_process(mct.MotherProcess());
-	grp.part.ancestor_position(mct.AncestorStart().X(),
-				   mct.AncestorStart().Y(),
-				   mct.AncestorStart().Z(),
-				   mct.AncestorStart().T());
-	grp.part.ancestor_track_id(mct.AncestorTrackID());
-	grp.part.ancestor_pdg_code(mct.AncestorPdgCode());
-	grp.part.ancestor_creation_process(mct.AncestorProcess());
+        auto& grp = part_grp_v[track_id];
+        assert(grp.part.group_id() == larcv::kINVALID_INSTANCEID);
+        /*
+        if(group_id < 0) {
+          group_id = group_counter + 1;
+          ++group_counter;
+        }
+        */
+        grp.part.group_id(group_id);
+        if(grp.first_pt.t == larcv::kINVALID_DOUBLE && mct.size())
+          grp.part.first_step(mct.front().X(),mct.front().Y(),mct.front().Z(),mct.front().T());
+        if(grp.last_pt.t == larcv::kINVALID_DOUBLE && mct.size())
+          grp.part.last_step(mct.back().X(),mct.back().Y(),mct.back().Z(),mct.back().T());
+        grp.part.parent_position(mct.MotherStart().X(),
+               mct.MotherStart().Y(),
+               mct.MotherStart().Z(),
+               mct.MotherStart().T());
+        grp.part.parent_creation_process(mct.MotherProcess());
+        grp.part.ancestor_position(mct.AncestorStart().X(),
+                 mct.AncestorStart().Y(),
+                 mct.AncestorStart().Z(),
+                 mct.AncestorStart().T());
+        grp.part.ancestor_track_id(mct.AncestorTrackID());
+        grp.part.ancestor_pdg_code(mct.AncestorPdgCode());
+        grp.part.ancestor_creation_process(mct.AncestorProcess());
       }
       for(size_t output_index=0; output_index<output2trackid.size(); ++output_index) {
-	int output_trackid = output2trackid[output_index];
-	auto& grp = part_grp_v[output_trackid];
-	if((int)(grp.part.parent_track_id()) != track_id) continue;
-	//group ID should not be distinct for track children
-	/*
-	if(group_id < 0) {
-	  group_id = group_counter + 1;
-	  ++group_counter;
-	}
-	*/
-	grp.part.group_id(output_index);
-	grp.part.ancestor_position(mct.AncestorStart().X(),
-				   mct.AncestorStart().Y(),
-				   mct.AncestorStart().Z(),
-				   mct.AncestorStart().T());
-	grp.part.ancestor_track_id(mct.AncestorTrackID());
-	grp.part.ancestor_pdg_code(mct.AncestorPdgCode());
-	grp.part.ancestor_creation_process(mct.AncestorProcess());
+        int output_trackid = output2trackid[output_index];
+        auto& grp = part_grp_v[output_trackid];
+        if((int)(grp.part.parent_track_id()) != track_id) continue;
+        //group ID should not be distinct for track children
+        /*
+        if(group_id < 0) {
+          group_id = group_counter + 1;
+          ++group_counter;
+        }
+        */
+        grp.part.group_id(output_index);
+        grp.part.ancestor_position(mct.AncestorStart().X(),
+                 mct.AncestorStart().Y(),
+                 mct.AncestorStart().Z(),
+                 mct.AncestorStart().T());
+        grp.part.ancestor_track_id(mct.AncestorTrackID());
+        grp.part.ancestor_pdg_code(mct.AncestorPdgCode());
+        grp.part.ancestor_creation_process(mct.AncestorProcess());
       }
     }
 
@@ -1460,7 +1445,7 @@ namespace larcv {
 
     // For shower orphans, we need to register the most base shower particle in the output (for group)
     LARCV_INFO() << "Searching the root (group) for kShapeShower particles w/ invalid group id... ("
-		 << output2trackid.size() << " particles total)" << std::endl;
+     << output2trackid.size() << " particles total)" << std::endl;
     for(size_t out_index=0; out_index<output2trackid.size(); ++out_index) {
 
       int trackid = output2trackid[out_index];
@@ -1469,8 +1454,8 @@ namespace larcv {
       if(grp.part.group_id() != larcv::kINVALID_INSTANCEID) continue;
       if(grp.shape() != larcv::kShapeShower) continue;
       LARCV_INFO() <<" #### SHOWER ROOT SEARCH: Analyzing a particle index " << out_index
-		   << " track id " << grp.part.track_id() << std::endl
-		   << grp.part.dump() << std::endl;
+       << " track id " << grp.part.track_id() << std::endl
+       << grp.part.dump() << std::endl;
 
       auto parent_trackid_v = this->ParentTrackIDs(trackid);
       int root_id = grp.part.id();
@@ -1479,56 +1464,56 @@ namespace larcv {
       std::vector<size_t> intermediate_trackid_v;
       intermediate_trackid_v.push_back(trackid);
       for(auto const& parent_trackid : parent_trackid_v) {
-	auto const& parent = part_grp_v[parent_trackid];
-	switch(parent.shape()) {
-	case larcv::kShapeShower:
-	case larcv::kShapeMichel:
-	case larcv::kShapeDelta:
-	  // group candidate: check if it is "valid" = exists in the output
-	  root_trackid = parent_trackid;
-	  root_id = trackid2output[root_trackid];
-	  if(root_id >= 0) {
-	    // found the valid group: stop the loop
-	    stop = true;
-	    // If not, root_id will be a new output index
-	  }else{
-	    root_id = output2trackid.size();
-	    // If this particle is invalid, this also needs the group id.
-	    // Add to intermediate_id_v list so we can set the group id for all of them
-	    intermediate_trackid_v.push_back(root_trackid);
-	  }
-	  stop = (stop || parent.shape() != larcv::kShapeShower);
-	  break;
-	case larcv::kShapeTrack:
-	  stop = true;
-	  break;
-	case larcv::kShapeUnknown:
-	  break;
-	case larcv::kShapeLEScatter:
-	case larcv::kShapeGhost:
-	  /*
-	  LARCV_CRITICAL() << "Unexpected type found while searching for kShapeShower orphans's root!" << std::endl;
-	  this->DumpHierarchy(trackid,part_grp_v);
-	  throw std::exception();
-	  */
-	  break;
-	};
-	if(stop) break;
+        auto const& parent = part_grp_v[parent_trackid];
+        switch(parent.shape()) {
+        case larcv::kShapeShower:
+        case larcv::kShapeMichel:
+        case larcv::kShapeDelta:
+          // group candidate: check if it is "valid" = exists in the output
+          root_trackid = parent_trackid;
+          root_id = trackid2output[root_trackid];
+          if(root_id >= 0) {
+            // found the valid group: stop the loop
+            stop = true;
+            // If not, root_id will be a new output index
+          }else{
+            root_id = output2trackid.size();
+            // If this particle is invalid, this also needs the group id.
+            // Add to intermediate_id_v list so we can set the group id for all of them
+            intermediate_trackid_v.push_back(root_trackid);
+          }
+          stop = (stop || parent.shape() != larcv::kShapeShower);
+          break;
+        case larcv::kShapeTrack:
+          stop = true;
+          break;
+        case larcv::kShapeUnknown:
+          break;
+        case larcv::kShapeLEScatter:
+        case larcv::kShapeGhost:
+          /*
+          LARCV_CRITICAL() << "Unexpected type found while searching for kShapeShower orphans's root!" << std::endl;
+          this->DumpHierarchy(trackid,part_grp_v);
+          throw std::exception();
+          */
+          break;
+        };
+        if(stop) break;
       }
       if( root_id < ((int)(output2trackid.size())) && trackid2output[root_trackid] != (int)(root_id) ) {
-	LARCV_CRITICAL() << "Logic error for the search of shower root particle for an orphan..." << std::endl
-			 << "This particle id=" << out_index << " and track_id=" << trackid << std::endl
-			 << "ROOT particle id=" << root_id  << " and track_id=" << root_trackid << std::endl;
-	this->DumpHierarchy(trackid,part_grp_v);
-	throw std::exception();
+        LARCV_CRITICAL() << "Logic error for the search of shower root particle for an orphan..." << std::endl
+             << "This particle id=" << out_index << " and track_id=" << trackid << std::endl
+             << "ROOT particle id=" << root_id  << " and track_id=" << root_trackid << std::endl;
+        this->DumpHierarchy(trackid,part_grp_v);
+        throw std::exception();
       }
 
       if(((int)(output2trackid.size())) <= root_id) {
-	output2trackid.push_back(root_trackid);
-	// Register the root parent to the output
-	LARCV_INFO() << "Adding a new particle to the output to define a group..." << std::endl
-		     << "ROOT particle id=" << root_id  << " and track_id=" << root_trackid << std::endl
-		     << part_grp_v[root_trackid].part.dump() << std::endl;
+        output2trackid.push_back(root_trackid);
+        // Register the root parent to the output
+        LARCV_INFO() << "Adding a new particle to the output to define a group..." << std::endl
+               << "ROOT particle id=" << root_id  << " and track_id=" << root_trackid << std::endl
+               << part_grp_v[root_trackid].part.dump() << std::endl;
       }
       assert((size_t)(root_id) < output2trackid.size());
 
@@ -1539,70 +1524,70 @@ namespace larcv {
       root.part.group_id(root_id);
       trackid2output[root_trackid] = root_id;
       for(auto const& child_id : root.part.children_id()) {
-	auto& child = part_grp_v[output2trackid[child_id]];
-	if(!child.valid) continue;
-	assert(child.part.group_id() == larcv::kINVALID_INSTANCEID || child.part.group_id() == root_id);
-	child.part.group_id(root_id);
+        auto& child = part_grp_v[output2trackid[child_id]];
+        if(!child.valid) continue;
+        assert(child.part.group_id() == larcv::kINVALID_INSTANCEID || child.part.group_id() == root_id);
+        child.part.group_id(root_id);
       }
       // Set the group ID for THIS + intermediate particles
       for(auto const& child_trackid : intermediate_trackid_v) {
-	auto& child = part_grp_v[child_trackid];
-	if(!child.valid) continue;
-	assert(child.part.group_id() == larcv::kINVALID_INSTANCEID || child.part.group_id() == root_id);
-	child.part.group_id(root_id);
+        auto& child = part_grp_v[child_trackid];
+        if(!child.valid) continue;
+        assert(child.part.group_id() == larcv::kINVALID_INSTANCEID || child.part.group_id() == root_id);
+        child.part.group_id(root_id);
       }
 
       LARCV_INFO() << "... after update ... " << std::endl
-		   << part_grp_v[trackid].part.dump() << std::endl;
+       << part_grp_v[trackid].part.dump() << std::endl;
     }
 
 
     // For LEScatter orphans, we need to register the immediate valid (=to be stored) particle
     LARCV_INFO() << "Searching the root (group) for kShapeLEScatter particles w/ invalid group id... ("
-		 << output2trackid.size() << " particles total)" << std::endl;
+     << output2trackid.size() << " particles total)" << std::endl;
     for(size_t out_index=0; out_index<output2trackid.size(); ++out_index) {
       int trackid = output2trackid[out_index];
       auto& grp = part_grp_v[trackid];
       if(grp.part.group_id() != larcv::kINVALID_INSTANCEID) continue;
       if(grp.shape() != larcv::kShapeLEScatter) continue;
       LARCV_INFO() <<" #### LEScatter ROOT SEARCH #### " << std::endl
-		   <<" Analyzing a particle index " << out_index << " id " << grp.part.id() << std::endl
-		   << grp.part.dump() << std::endl;
+       <<" Analyzing a particle index " << out_index << " id " << grp.part.id() << std::endl
+       << grp.part.dump() << std::endl;
 
       auto parent_trackid_v = this->ParentTrackIDs(trackid);
       size_t group_id = larcv::kINVALID_INSTANCEID;
       bool stop = false;
       for(auto const& parent_trackid : parent_trackid_v) {
-	auto const& parent = part_grp_v[parent_trackid];
-	switch(parent.shape()) {
-	case larcv::kShapeShower:
-	case larcv::kShapeMichel:
-	case larcv::kShapeDelta:
-	case larcv::kShapeTrack:
-	case larcv::kShapeLEScatter:
-	  // group candidate: check if it is "valid" = exists in the output
-	  if(parent.valid) {
-	    group_id = trackid2output[parent_trackid];
-	    // found the valid group: stop the loop
-	    stop = true;
-	  }
-	  break;
-	case larcv::kShapeUnknown:
-	case larcv::kShapeGhost:
-	  LARCV_CRITICAL() << "Unexpected type found while searching for kShapeLEScatter orphans's root!" << std::endl;
-	  throw std::exception();
-	  break;
-	};
-	if(stop) break;
+        auto const& parent = part_grp_v[parent_trackid];
+        switch(parent.shape()) {
+        case larcv::kShapeShower:
+        case larcv::kShapeMichel:
+        case larcv::kShapeDelta:
+        case larcv::kShapeTrack:
+        case larcv::kShapeLEScatter:
+          // group candidate: check if it is "valid" = exists in the output
+          if(parent.valid) {
+            group_id = trackid2output[parent_trackid];
+            // found the valid group: stop the loop
+            stop = true;
+          }
+          break;
+        case larcv::kShapeUnknown:
+        case larcv::kShapeGhost:
+          LARCV_CRITICAL() << "Unexpected type found while searching for kShapeLEScatter orphans's root!" << std::endl;
+          throw std::exception();
+          break;
+        };
+        if(stop) break;
       }
       if(group_id == larcv::kINVALID_INSTANCEID) {
-	LARCV_INFO() << "Ignoring kShapeLEScatter particle as its root particle (for group id) is not to be stored..." << std::endl
-		     << grp.part.dump() << std::endl;
-	continue;
+        LARCV_INFO() << "Ignoring kShapeLEScatter particle as its root particle (for group id) is not to be stored..." << std::endl
+               << grp.part.dump() << std::endl;
+        continue;
       }
       LARCV_INFO() << "Assigning a group ID " << group_id << " to kShapeLEScatter orphan" << std::endl
-		   << "  Track ID " << grp.part.track_id() << " PDG " << grp.part.pdg_code()
-		   << " " << grp.part.creation_process() << std::endl;
+       << "  Track ID " << grp.part.track_id() << " PDG " << grp.part.pdg_code()
+       << " " << grp.part.creation_process() << std::endl;
       grp.part.group_id(group_id);
       trackid2output[trackid] = group_id;
     }
@@ -1610,30 +1595,30 @@ namespace larcv {
 
     // for shower particles with invalid parent ID, attempt a search
     LARCV_INFO() << "Searching parents for shower particles w/ invalid parent id... ("
-		 << output2trackid.size() << " particles total)" << std::endl;
+     << output2trackid.size() << " particles total)" << std::endl;
     for(size_t out_index=0; out_index<output2trackid.size(); ++out_index) {
       int trackid = output2trackid[out_index];
       auto& grp = part_grp_v[trackid];
       if(!grp.valid) continue;
       if(grp.part.parent_id() != larcv::kINVALID_INSTANCEID) continue;
       if(grp.shape() != larcv::kShapeShower)
-	continue;
+        continue;
       LARCV_INFO() << "Analyzing particle id " << out_index << " trackid " << trackid << std::endl
-		   << grp.part.dump() << std::endl;
+       << grp.part.dump() << std::endl;
       int parent_partid = -1;
       unsigned int parent_trackid;
       auto parent_trackid_v = this->ParentTrackIDs(trackid);
       for(size_t idx=0; idx<parent_trackid_v.size(); ++idx) {
-	parent_trackid = parent_trackid_v[idx];
-	if(trackid2output[parent_trackid] < 0 || !part_grp_v[parent_trackid].valid)
-	  continue;
-	auto const& parent = part_grp_v[parent_trackid].part;
-	// shower parent can be either shower, michel, or delta
-	if(parent.shape() == larcv::kShapeMichel ||
-	   parent.shape() == larcv::kShapeDelta  ||
-	   parent.shape() == larcv::kShapeShower)
-	  parent_partid  = parent.id();
-	break;
+        parent_trackid = parent_trackid_v[idx];
+        if(trackid2output[parent_trackid] < 0 || !part_grp_v[parent_trackid].valid)
+          continue;
+        auto const& parent = part_grp_v[parent_trackid].part;
+        // shower parent can be either shower, michel, or delta
+        if(parent.shape() == larcv::kShapeMichel ||
+           parent.shape() == larcv::kShapeDelta  ||
+           parent.shape() == larcv::kShapeShower)
+          parent_partid  = parent.id();
+        break;
       }
       /*
       int own_partid = grp.part.id();
@@ -1641,42 +1626,42 @@ namespace larcv {
       int parent_trackid = grp.part.parent_track_id();
       int parent_partid  = -1;
       while(1) {
-	if(parent_trackid >= ((int)(trackid2index.size())) || trackid2index[parent_trackid] <0)
-	  break;
-	if(parent_trackid < ((int)(trackid2output.size())) &&
-	   trackid2output[parent_trackid] >= 0 &&
-	   part_grp_v[parent_trackid].valid ) {
-	  //parent_partid = trackid2output[parent_trackid];
-	  parent_partid = part_grp_v[parent_trackid].part.id();
-	  break;
-	}
-	parent_trackid = larmcp_v[trackid2index[parent_trackid]].Mother();
+        if(parent_trackid >= ((int)(trackid2index.size())) || trackid2index[parent_trackid] <0)
+          break;
+        if(parent_trackid < ((int)(trackid2output.size())) &&
+           trackid2output[parent_trackid] >= 0 &&
+           part_grp_v[parent_trackid].valid ) {
+          //parent_partid = trackid2output[parent_trackid];
+          parent_partid = part_grp_v[parent_trackid].part.id();
+          break;
+        }
+        parent_trackid = larmcp_v[trackid2index[parent_trackid]].Mother();
       }
       */
       if(parent_partid >=0) {
-	// assert the group is same
-	auto& parent = part_grp_v[output2trackid[parent_partid]];
-	if(grp.part.group_id() == larcv::kINVALID_INSTANCEID) {
-	  grp.part.group_id(parent.part.group_id());
-	  for(auto const& child_id : grp.part.children_id()) {
-	    auto& child = part_grp_v[output2trackid[child_id]];
-	    child.part.group_id(parent.part.group_id());
-	  }
-	}else{
-	  assert(grp.part.group_id() == part_grp_v[output2trackid[parent_partid]].group_id());
-	}
-	grp.part.parent_id(parent_partid);
-	part_grp_v[parent_trackid].part.children_id(grp.part.id());
-	LARCV_INFO() << "PartID " << grp.part.id() << " (output index " << out_index << ") assigning parent " << parent_partid << std::endl;
+        // assert the group is same
+        auto& parent = part_grp_v[output2trackid[parent_partid]];
+        if(grp.part.group_id() == larcv::kINVALID_INSTANCEID) {
+          grp.part.group_id(parent.part.group_id());
+          for(auto const& child_id : grp.part.children_id()) {
+            auto& child = part_grp_v[output2trackid[child_id]];
+            child.part.group_id(parent.part.group_id());
+          }
+        }else{
+          assert(grp.part.group_id() == part_grp_v[output2trackid[parent_partid]].group_id());
+        }
+        grp.part.parent_id(parent_partid);
+        part_grp_v[parent_trackid].part.children_id(grp.part.id());
+        LARCV_INFO() << "PartID " << grp.part.id() << " (output index " << out_index << ") assigning parent " << parent_partid << std::endl;
       }else{
-	grp.part.parent_id(grp.part.id());
-	if(grp.part.group_id() == larcv::kINVALID_INSTANCEID)
-	  grp.part.group_id(grp.part.id());
-	for(auto const& child_id : grp.part.children_id()) {
-	  auto& child = part_grp_v[output2trackid[child_id]];
-	  child.part.group_id(grp.part.id());
-	}
-	LARCV_INFO() << "PartID " << grp.part.id() << " (output index " << out_index << ") assigning itself as a parent..." << std::endl;
+        grp.part.parent_id(grp.part.id());
+        if(grp.part.group_id() == larcv::kINVALID_INSTANCEID)
+          grp.part.group_id(grp.part.id());
+        for(auto const& child_id : grp.part.children_id()) {
+          auto& child = part_grp_v[output2trackid[child_id]];
+          child.part.group_id(grp.part.id());
+        }
+        LARCV_INFO() << "PartID " << grp.part.id() << " (output index " << out_index << ") assigning itself as a parent..." << std::endl;
       }
     }
 
@@ -1684,7 +1669,7 @@ namespace larcv {
     // Now sort out all parent IDs where it's simply not assigned
     // (it's ok to have invalid parent id if parent track id is not stored)
     LARCV_INFO() << "Check all output particle's parent id... ("
-		 << output2trackid.size() << " particles total)" << std::endl;
+     << output2trackid.size() << " particles total)" << std::endl;
     for(size_t output_index=0; output_index<output2trackid.size(); ++output_index) {
       auto& grp = part_grp_v[output2trackid[output_index]];
       auto parent_trackid = grp.part.parent_track_id();
@@ -1692,17 +1677,17 @@ namespace larcv {
       auto& parent = part_grp_v[parent_trackid].part;
       // if parent_id is invalid, try if parent_trackid can help out
       if(parent_id == larcv::kINVALID_INSTANCEID &&
-	 trackid2output[parent_trackid] >= 0) {
-	parent_id = trackid2output[parent_trackid];
-	grp.part.parent_id(parent_id);
+         trackid2output[parent_trackid] >= 0) {
+        parent_id = trackid2output[parent_trackid];
+        grp.part.parent_id(parent_id);
       }
       if(parent_id == larcv::kINVALID_INSTANCEID) continue;
       // if parent id is set, make sure this particle is in the children
       auto children = parent.children_id();
       bool add=true;
       for(auto const& child : children) {
-	if(child != grp.part.id()) continue;
-	add = false; break;
+        if(child != grp.part.id()) continue;
+        add = false; break;
       }
       if(add) {children.push_back(grp.part.id()); parent.children_id(children);}
     }
@@ -1710,7 +1695,7 @@ namespace larcv {
     // Now loop over otuput particle list and check if any remaining group id needs to be assigned
     // Use its parent to group...
     LARCV_INFO() <<  "Check all output particles for their group id... ("
-		 << output2trackid.size() << " particles total)" << std::endl;
+     << output2trackid.size() << " particles total)" << std::endl;
     for(size_t output_index=0; output_index<output2trackid.size(); ++output_index) {
       auto& grp = part_grp_v[output2trackid[output_index]];
       if(grp.part.group_id() != larcv::kINVALID_INSTANCEID) continue;
@@ -1722,68 +1707,68 @@ namespace larcv {
 
       switch(shape) {
       case larcv::kShapeLEScatter:
-	// if LEScatter, we handle later (next loop)
-	break;
+        // if LEScatter, we handle later (next loop)
+        break;
       case larcv::kShapeDelta:
       case larcv::kShapeMichel:
       case larcv::kShapeTrack:
-	// If delta, Michel, or track, it's own group
-	grp.part.group_id(output_index);
-	for(auto const& child_index : grp.part.children_id()) {
-	  part_grp_v[output2trackid[child_index]].part.group_id(output_index);
-	}
-	break;
+        // If delta, Michel, or track, it's own group
+        grp.part.group_id(output_index);
+        for(auto const& child_index : grp.part.children_id()) {
+          part_grp_v[output2trackid[child_index]].part.group_id(output_index);
+        }
+        break;
 
       case larcv::kShapeShower:
-	// If shower && no parent, consider it as a primary = assign group id for all children
-	if(parent_partid == kINVALID_INSTANCEID) {
-	  grp.part.group_id(output_index);
-	  for(auto const& child_index : grp.part.children_id())
-	    part_grp_v[output2trackid[child_index]].part.group_id(output_index);
-	  continue;
-	}
-	parent_shape = part_grp_v[output2trackid[parent_partid]].shape();
-	switch(parent_shape) {
-	case larcv::kShapeMichel:
-	case larcv::kShapeDelta:
-	  grp.part.group_id(parent_partid);
-	  for(auto const& child_index : grp.part.children_id()) {
-	    part_grp_v[output2trackid[child_index]].part.group_id(parent_partid);
-	  }
-	  break;
-	case larcv::kShapeTrack:
-	  grp.part.group_id(output_index);
-	  for(auto const& child_index : grp.part.children_id()) {
-	    part_grp_v[output2trackid[child_index]].part.group_id(output_index);
-	  }
-	  break;
-	case larcv::kShapeShower:
-	  LARCV_CRITICAL() << "Unexpected case: a shower has no group id while being a child of another shower..." << std::endl;
-	  this->DumpHierarchy(grp.part.track_id(),part_grp_v);
-	  throw std::exception();
-	  /*
-	  // COMMENTED OUT as this is no longer expected
-	  parent_groupid = part_grp_v[output2trackid[parent_partid]].part.group_id();
-	  if(parent_groupid != larcv::kINVALID_INSTANCEID) {
-	    grp.part.group_id(parent_groupid);
-	    for(auto const& child_index : grp.part.children_id()) {
-	      part_grp_v[output2trackid[child_index]].part.group_id(parent_groupid);
-	    }
-	  }
-	  */
-	  break;
-	case larcv::kShapeLEScatter:
-	  LARCV_ERROR() << "Logic error: shower parent shape cannot be LEScatter!" <<std::endl;
-	  throw std::exception();
-	default:
-	  LARCV_ERROR() << "Unexpected larcv::ShapeType_t encountered at " << __LINE__ <<std::endl;
-	  throw std::exception();
-	};
-	break;
-      case larcv::kShapeGhost:
-      case larcv::kShapeUnknown:
-	LARCV_ERROR() << "Unexpected larcv::ShapeType_t encountered at " << __LINE__ <<std::endl;
-	throw std::exception();
+        // If shower && no parent, consider it as a primary = assign group id for all children
+        if(parent_partid == kINVALID_INSTANCEID) {
+          grp.part.group_id(output_index);
+          for(auto const& child_index : grp.part.children_id())
+            part_grp_v[output2trackid[child_index]].part.group_id(output_index);
+          continue;
+        }
+        parent_shape = part_grp_v[output2trackid[parent_partid]].shape();
+        switch(parent_shape) {
+        case larcv::kShapeMichel:
+        case larcv::kShapeDelta:
+          grp.part.group_id(parent_partid);
+          for(auto const& child_index : grp.part.children_id()) {
+            part_grp_v[output2trackid[child_index]].part.group_id(parent_partid);
+          }
+          break;
+        case larcv::kShapeTrack:
+          grp.part.group_id(output_index);
+          for(auto const& child_index : grp.part.children_id()) {
+            part_grp_v[output2trackid[child_index]].part.group_id(output_index);
+          }
+          break;
+        case larcv::kShapeShower:
+          LARCV_CRITICAL() << "Unexpected case: a shower has no group id while being a child of another shower..." << std::endl;
+          this->DumpHierarchy(grp.part.track_id(),part_grp_v);
+          throw std::exception();
+          /*
+          // COMMENTED OUT as this is no longer expected
+          parent_groupid = part_grp_v[output2trackid[parent_partid]].part.group_id();
+          if(parent_groupid != larcv::kINVALID_INSTANCEID) {
+            grp.part.group_id(parent_groupid);
+            for(auto const& child_index : grp.part.children_id()) {
+              part_grp_v[output2trackid[child_index]].part.group_id(parent_groupid);
+            }
+          }
+          */
+          break;
+        case larcv::kShapeLEScatter:
+          LARCV_ERROR() << "Logic error: shower parent shape cannot be LEScatter!" <<std::endl;
+          throw std::exception();
+        default:
+          LARCV_ERROR() << "Unexpected larcv::ShapeType_t encountered at " << __LINE__ <<std::endl;
+          throw std::exception();
+        };
+        break;
+            case larcv::kShapeGhost:
+            case larcv::kShapeUnknown:
+        LARCV_ERROR() << "Unexpected larcv::ShapeType_t encountered at " << __LINE__ <<std::endl;
+        throw std::exception();
       }
     };
 
@@ -1801,21 +1786,21 @@ namespace larcv {
 
     // Next handle LEScatter group id if not assigned yet
     LARCV_INFO() <<  "Check LEScatter particle's group id ... ("
-		 << output2trackid.size() << " particles total)" << std::endl;
+     << output2trackid.size() << " particles total)" << std::endl;
     for(size_t output_index=0; output_index<output2trackid.size(); ++output_index) {
       auto& grp = part_grp_v[output2trackid[output_index]];
       if(grp.part.group_id() != larcv::kINVALID_INSTANCEID) continue;
       if(grp.shape() == larcv::kShapeLEScatter) {
-	// assign parent's group, otherwise leave as is = kINVALID_INSTANCEID
-	auto parent_partid = grp.part.parent_id();
-	if(parent_partid == larcv::kINVALID_INSTANCEID) continue;
-	grp.part.group_id( part_grp_v[output2trackid[parent_partid]].part.group_id() );
+        // assign parent's group, otherwise leave as is = kINVALID_INSTANCEID
+        auto parent_partid = grp.part.parent_id();
+        if(parent_partid == larcv::kINVALID_INSTANCEID) continue;
+        grp.part.group_id( part_grp_v[output2trackid[parent_partid]].part.group_id() );
       }
     }
 
     // Next loop over to find any particle for which first_step is not defined
     LARCV_INFO() <<  "Check any particle's first step ... ("
-		 << output2trackid.size() << " particles total)" << std::endl;
+     << output2trackid.size() << " particles total)" << std::endl;
     for(size_t output_index=0; output_index<output2trackid.size(); ++output_index) {
       auto& grp = part_grp_v[output2trackid[output_index]];
       auto const& fs = grp.part.first_step();
@@ -1824,11 +1809,11 @@ namespace larcv {
       double min_dist = std::fabs(larcv::kINVALID_DOUBLE);
       larcv::Point3D min_pt;
       for(auto const& vox : grp.vs.as_vector()) {
-	auto const pt = meta3d.position(vox.id());
-	double dist = pt.squared_distance(vtx);
-	if(dist > min_dist) continue;
-	min_dist = dist;
-	min_pt = pt;
+        auto const pt = meta3d.position(vox.id());
+        double dist = pt.squared_distance(vtx);
+        if(dist > min_dist) continue;
+        min_dist = dist;
+        min_pt = pt;
       }
       if(min_dist > (sqrt(3.) + 1.e-3)) grp.part.first_step(larcv::kINVALID_DOUBLE,larcv::kINVALID_DOUBLE,larcv::kINVALID_DOUBLE,larcv::kINVALID_DOUBLE);
       else grp.part.first_step(min_pt.x, min_pt.y, min_pt.z, grp.part.position().t());
@@ -1849,31 +1834,31 @@ namespace larcv {
       auto const& larmcp_index = trackid2index[trackid];
       auto& p = part_grp_v[trackid].part;
       if(larmcp_index < 0) {
-	LARCV_CRITICAL() << "Unexpected logiv error (simb::MCParticle must be found for a particle track id)" << std::endl;
-	throw larbys();
-	continue;
+        LARCV_CRITICAL() << "Unexpected logiv error (simb::MCParticle must be found for a particle track id)" << std::endl;
+        throw larbys();
+        continue;
       }
       auto const& ancestor_index = ancestor_index_v[larmcp_index];
       if(ancestor_index < 0) {
-	// unknown ancestor
-	no_ancestor_count++;
-	no_ancestor_energy_sum += p.energy_deposit();
-	continue;
+        // unknown ancestor
+        no_ancestor_count++;
+        no_ancestor_energy_sum += p.energy_deposit();
+        continue;
       }
       auto const& ancestor = larmcp_v[ancestor_index];
       larcv::Vertex apos (ancestor.Vx(),ancestor.Vy(),ancestor.Vz(),ancestor.T());
       int aid = -1;
       for(size_t iid=0; iid<int2vtx.size(); ++iid)
-	{
-	  auto const& vtx = int2vtx[iid];
-	  if(vtx == apos) {
-	    aid = iid;
-	    break;
-	  }
-	}
+      {
+        auto const& vtx = int2vtx[iid];
+        if(vtx == apos) {
+          aid = iid;
+          break;
+        }
+      }
       if(aid<0) {
-	aid = int2vtx.size();
-	int2vtx.push_back(apos);
+        aid = int2vtx.size();
+        int2vtx.push_back(apos);
       }
       p.interaction_id(aid);
     }
@@ -1944,31 +1929,31 @@ namespace larcv {
       // set semantic type
       larcv::ShapeType_t semantic = grp.shape();
       if(semantic == larcv::kShapeUnknown) {
-	LARCV_CRITICAL() << "Unexpected type while assigning semantic class: " << grp.type << std::endl;
-	auto const& part = grp.part;
-	LARCV_CRITICAL() << "Particle ID " << part.id() << " Type " << grp.type << " Valid " << grp.valid
-			 << " Track ID " << part.track_id() << " PDG " << part.pdg_code()
-			 << " " << part.creation_process() << " ... " << part.energy_init() << " MeV => " << part.energy_deposit() << " MeV "
-			 << grp.trackid_v.size() << " children " << grp.vs.size() << " voxels " << grp.vs.sum() << " MeV" << std::endl;
-	LARCV_CRITICAL() << "  Parent " << part.parent_track_id() << " PDG " << part.parent_pdg_code()
-			 << " " << part.parent_creation_process() << " Ancestor " << part.ancestor_track_id()
-			 << " PDG " << part.ancestor_pdg_code() << " " << part.ancestor_creation_process() << std::endl;
+        LARCV_CRITICAL() << "Unexpected type while assigning semantic class: " << grp.type << std::endl;
+        auto const& part = grp.part;
+        LARCV_CRITICAL() << "Particle ID " << part.id() << " Type " << grp.type << " Valid " << grp.valid
+             << " Track ID " << part.track_id() << " PDG " << part.pdg_code()
+             << " " << part.creation_process() << " ... " << part.energy_init() << " MeV => " << part.energy_deposit() << " MeV "
+             << grp.trackid_v.size() << " children " << grp.vs.size() << " voxels " << grp.vs.sum() << " MeV" << std::endl;
+        LARCV_CRITICAL() << "  Parent " << part.parent_track_id() << " PDG " << part.parent_pdg_code()
+             << " " << part.parent_creation_process() << " Ancestor " << part.ancestor_track_id()
+             << " PDG " << part.ancestor_pdg_code() << " " << part.ancestor_creation_process() << std::endl;
 
 
-	throw std::exception();
+        throw std::exception();
       }
       if(semantic == larcv::kShapeLEScatter && mcs_trackid_s.find(trackid) == mcs_trackid_s.end()) {
-	LARCV_CRITICAL() << "Unexpected particle to be stored with a shape kShapeLEScatter!" << std::endl;
-	this->DumpHierarchy(grp.part.track_id(),part_grp_v);
-	throw std::exception();
+        LARCV_CRITICAL() << "Unexpected particle to be stored with a shape kShapeLEScatter!" << std::endl;
+        this->DumpHierarchy(grp.part.track_id(),part_grp_v);
+        throw std::exception();
       }
       // Now, we will re-classify some of non LEScatter showers based on pixel count
       // (BUG FIX: use pca or something better)
       if(grp.vs.size() < _compton_size) {
-	LARCV_INFO() << "Particle ID " << grp.part.id() << " PDG " << grp.part.pdg_code() << " " << grp.part.creation_process() << std::endl
-		     << "  ... type switching " << grp.part.shape() << " => " << larcv::kShapeLEScatter
-		     << " (voxel count " << grp.vs.size() << " < " << _compton_size << ")" << std::endl;
-	semantic = larcv::kShapeLEScatter;
+        LARCV_INFO() << "Particle ID " << grp.part.id() << " PDG " << grp.part.pdg_code() << " " << grp.part.creation_process() << std::endl
+               << "  ... type switching " << grp.part.shape() << " => " << larcv::kShapeLEScatter
+               << " (voxel count " << grp.vs.size() << " < " << _compton_size << ")" << std::endl;
+        semantic = larcv::kShapeLEScatter;
       }
       // store the shape (semantic) type in particle
       grp.part.shape(semantic);
@@ -1981,33 +1966,33 @@ namespace larcv {
       // fill 3d cluster
       event_cluster->writeable_voxel_set(index) = grp.vs;
       if(semantic != kShapeLEScatter)
-	event_cluster_he->writeable_voxel_set(index) = grp.vs;
+        event_cluster_he->writeable_voxel_set(index) = grp.vs;
       else {
-	event_cluster_le->writeable_voxel_set(index) = grp.vs;
-	for(auto const& vox : grp.vs.as_vector())
-	  cid_vs.emplace(vox.id(),index,false);
+        event_cluster_le->writeable_voxel_set(index) = grp.vs;
+        for(auto const& vox : grp.vs.as_vector())
+          cid_vs.emplace(vox.id(),index,false);
       }
       // fill 3d dedx
       if(_store_dedx) {
-	event_dedx->writeable_voxel_set(index) = grp.dedx;
-	if(semantic != kShapeLEScatter)
-	  event_dedx_he->writeable_voxel_set(index) = grp.dedx;
-	else
-	  event_dedx_le->writeable_voxel_set(index) = grp.dedx;
+        event_dedx->writeable_voxel_set(index) = grp.dedx;
+        if(semantic != kShapeLEScatter)
+          event_dedx_he->writeable_voxel_set(index) = grp.dedx;
+        else
+          event_dedx_le->writeable_voxel_set(index) = grp.dedx;
       }
       //grp.vs.clear_data();
       // fill 2d cluster
       for(size_t plane_idx=0; plane_idx<_valid_nplanes; ++plane_idx) {
-	auto& vsa2d = vsa2d_v[plane_idx];
-	vsa2d.writeable_voxel_set(index) = grp.vs2d_v[plane_idx];
-	if(semantic != kShapeLEScatter) {
-	  auto& vsa2d_he = vsa2d_he_v[plane_idx];
-	  vsa2d_he.writeable_voxel_set(index) = grp.vs2d_v[plane_idx];
-	}else{
-	  auto& vsa2d_le = vsa2d_le_v[plane_idx];
-	  vsa2d_le.writeable_voxel_set(index) = grp.vs2d_v[plane_idx];
-	}
-	grp.vs2d_v[plane_idx].clear_data();
+        auto& vsa2d = vsa2d_v[plane_idx];
+        vsa2d.writeable_voxel_set(index) = grp.vs2d_v[plane_idx];
+        if(semantic != kShapeLEScatter) {
+          auto& vsa2d_he = vsa2d_he_v[plane_idx];
+          vsa2d_he.writeable_voxel_set(index) = grp.vs2d_v[plane_idx];
+        }else{
+          auto& vsa2d_le = vsa2d_le_v[plane_idx];
+          vsa2d_le.writeable_voxel_set(index) = grp.vs2d_v[plane_idx];
+        }
+        grp.vs2d_v[plane_idx].clear_data();
       }
       grp.valid=false;
     }
@@ -2021,27 +2006,27 @@ namespace larcv {
       if(grp.size_all()<1) continue;
       auto semantic = grp.shape();
       if(semantic != larcv::kShapeLEScatter) {
-	LARCV_CRITICAL() << "Unexpected, valid, >1 pixel count particle type "
-			 << semantic << " pixel count " << grp.vs.size()
-			 << " (not kShapeLEScatter) at line " << __LINE__
-			 << std::endl;
-	std::cout<<grp.part.dump()<<std::endl;
-	throw std::exception();
+        LARCV_CRITICAL() << "Unexpected, valid, >1 pixel count particle type "
+             << semantic << " pixel count " << grp.vs.size()
+             << " (not kShapeLEScatter) at line " << __LINE__
+             << std::endl;
+        std::cout<<grp.part.dump()<<std::endl;
+        throw std::exception();
       }
       int trackid = grp.part.parent_track_id();
       int output_index = -1;
       if(trackid < ((int)(trackid2output.size()))) output_index = trackid2output[trackid];
       if(output_index<0) {
-	// search the first direct, valid parent
-	// START_HERE 2020-04-23 ... use ParentTrackIDs(), make sure output_index is not int max
-	while(1) {
-	  if(trackid >= ((int)(trackid2index.size())) || trackid2index[trackid] < 0) break;
-	  trackid = larmcp_v[trackid2index[trackid]].Mother();
-	  if(trackid < ((int)(trackid2output.size()))) {
-	    output_index = trackid2output[trackid];
-	    break;
-	  }
-	}
+        // search the first direct, valid parent
+        // START_HERE 2020-04-23 ... use ParentTrackIDs(), make sure output_index is not int max
+        while(1) {
+          if(trackid >= ((int)(trackid2index.size())) || trackid2index[trackid] < 0) break;
+          trackid = larmcp_v[trackid2index[trackid]].Mother();
+          if(trackid < ((int)(trackid2output.size()))) {
+            output_index = trackid2output[trackid];
+            break;
+          }
+        }
       }
       //std::cout<<"Inspecting Track ID " << grp.part.track_id() << " found output ID " << output_index << std::endl;
       if(output_index<0) continue;
@@ -2049,14 +2034,14 @@ namespace larcv {
       /*
       # cross-check that touching LEScatter is not the same as found output_index
       for(size_t out_index=0; out_index < output2trackid.size(); ++out_index) {
-	bool touching = this->IsTouching(meta3d,grp.vs,part_grp_v[output2trackid[out_index]].vs);
-	if(touching && output_index == (int)(out_index)) {
-	  auto const& parent = part_grp_v[output2trackid[out_index]];
-	  std::cout<< "  Parent Track ID " << parent.part.track_id()
-		   << " PDG " << parent.part.pdg_code()
-		   << " " << parent.part.creation_process() << std::endl;
-	  throw std::exception();
-	}
+        bool touching = this->IsTouching(meta3d,grp.vs,part_grp_v[output2trackid[out_index]].vs);
+        if(touching && output_index == (int)(out_index)) {
+          auto const& parent = part_grp_v[output2trackid[out_index]];
+          std::cout<< "  Parent Track ID " << parent.part.track_id()
+             << " PDG " << parent.part.pdg_code()
+             << " " << parent.part.creation_process() << std::endl;
+          throw std::exception();
+        }
       }
       */
 
@@ -2064,29 +2049,29 @@ namespace larcv {
       auto& vs_le = event_cluster_le->writeable_voxel_set(output_index);
       auto& vs    = event_cluster->writeable_voxel_set(output_index);
       for(auto const& vox : grp.vs.as_vector()) {
-	vs_le.emplace(vox.id(),vox.value(),true);
-	vs.emplace(vox.id(),vox.value(),true);
-	cid_vs.emplace(vox.id(),output_index,false);
+        vs_le.emplace(vox.id(),vox.value(),true);
+        vs.emplace(vox.id(),vox.value(),true);
+        cid_vs.emplace(vox.id(),output_index,false);
       }
       if(_store_dedx) {
-	auto& dedx_le = event_dedx_le->writeable_voxel_set(output_index);
-	auto& dedx    = event_dedx->writeable_voxel_set(output_index);
-	for(auto const& vox : grp.dedx.as_vector()) {
-	  dedx_le.emplace(vox.id(),vox.value(),true);
-	  dedx.emplace(vox.id(),vox.value(),true);
-	}
+        auto& dedx_le = event_dedx_le->writeable_voxel_set(output_index);
+        auto& dedx    = event_dedx->writeable_voxel_set(output_index);
+        for(auto const& vox : grp.dedx.as_vector()) {
+          dedx_le.emplace(vox.id(),vox.value(),true);
+          dedx.emplace(vox.id(),vox.value(),true);
+        }
       }
       grp.vs.clear_data();
       grp.dedx.clear_data();
       // fill 2d cluster
       for(size_t plane_idx=0; plane_idx<_valid_nplanes; ++plane_idx) {
-	auto& vs2d = vsa2d_v[plane_idx].writeable_voxel_set(output_index);
-	auto& vs2d_le = vsa2d_le_v[plane_idx].writeable_voxel_set(output_index);
-	for(auto const& vox : grp.vs2d_v[plane_idx].as_vector()) {
-	  vs2d.emplace(vox.id(),vox.value(),true);
-	  vs2d_le.emplace(vox.id(),vox.value(),true);
-	}
-	grp.vs2d_v[plane_idx].clear_data();
+        auto& vs2d = vsa2d_v[plane_idx].writeable_voxel_set(output_index);
+        auto& vs2d_le = vsa2d_le_v[plane_idx].writeable_voxel_set(output_index);
+        for(auto const& vox : grp.vs2d_v[plane_idx].as_vector()) {
+          vs2d.emplace(vox.id(),vox.value(),true);
+          vs2d_le.emplace(vox.id(),vox.value(),true);
+        }
+        grp.vs2d_v[plane_idx].clear_data();
       }
     }
 
@@ -2109,34 +2094,34 @@ namespace larcv {
     if(total_vs_size > output_vs_size) {
       int ctr= 0;
       for(auto& grp : part_grp_v) {
-	if(grp.size_all()<1) continue;
-	for(auto const& vox : grp.vs.as_vector())   leftover_vs.emplace(vox.id(),vox.value(),true);
-	for(auto const& vox : grp.dedx.as_vector()) leftover_dedx.emplace(vox.id(),vox.value(),true);
-	for(size_t plane_idx=0; plane_idx<_valid_nplanes; ++plane_idx) {
-	  for(auto const& vox : grp.vs2d_v[plane_idx].as_vector()) {
-	    leftover2d_vs[plane_idx].emplace(vox.id(),vox.value(),true);
-	  }
-	}
-	ctr++;
-	auto const& part = grp.part;
-	LARCV_INFO() << "Particle ID " << part.id() << " Type " << grp.type << " Valid " << grp.valid << " Track ID " << part.track_id() << " PDG " << part.pdg_code()
-		     << " " << part.creation_process() << " ... " << part.energy_init() << " MeV => " << part.energy_deposit() << " MeV "
-		     << grp.trackid_v.size() << " children " << grp.vs.size() << " voxels " << grp.vs.sum() << " MeV" << std::endl;
-	LARCV_INFO() << "  Parent " << part.parent_track_id() << " PDG " << part.parent_pdg_code() << " " << part.parent_creation_process()
-		     << " Ancestor " << part.ancestor_track_id() << " PDG " << part.ancestor_pdg_code() << " " << part.ancestor_creation_process() << std::endl;
-	LARCV_INFO() << "  Group ID: " << part.group_id() << std::endl;
-	std::stringstream ss1,ss2;
+        if(grp.size_all()<1) continue;
+        for(auto const& vox : grp.vs.as_vector())   leftover_vs.emplace(vox.id(),vox.value(),true);
+        for(auto const& vox : grp.dedx.as_vector()) leftover_dedx.emplace(vox.id(),vox.value(),true);
+        for(size_t plane_idx=0; plane_idx<_valid_nplanes; ++plane_idx) {
+          for(auto const& vox : grp.vs2d_v[plane_idx].as_vector()) {
+            leftover2d_vs[plane_idx].emplace(vox.id(),vox.value(),true);
+          }
+        }
+        ctr++;
+        auto const& part = grp.part;
+        LARCV_INFO() << "Particle ID " << part.id() << " Type " << grp.type << " Valid " << grp.valid << " Track ID " << part.track_id() << " PDG " << part.pdg_code()
+               << " " << part.creation_process() << " ... " << part.energy_init() << " MeV => " << part.energy_deposit() << " MeV "
+               << grp.trackid_v.size() << " children " << grp.vs.size() << " voxels " << grp.vs.sum() << " MeV" << std::endl;
+        LARCV_INFO() << "  Parent " << part.parent_track_id() << " PDG " << part.parent_pdg_code() << " " << part.parent_creation_process()
+               << " Ancestor " << part.ancestor_track_id() << " PDG " << part.ancestor_pdg_code() << " " << part.ancestor_creation_process() << std::endl;
+        LARCV_INFO() << "  Group ID: " << part.group_id() << std::endl;
+        std::stringstream ss1,ss2;
 
-	ss1 << "  Children particle IDs: " << std::flush;
-	for(auto const& child : part.children_id()) ss1 << child << " " << std::flush;
-	ss1 << std::endl;
-	LARCV_INFO() << ss1.str();
+        ss1 << "  Children particle IDs: " << std::flush;
+        for(auto const& child : part.children_id()) ss1 << child << " " << std::flush;
+        ss1 << std::endl;
+        LARCV_INFO() << ss1.str();
 
-	ss2 << "  Children track IDs: " << std::flush;
-	for(auto const& child : grp.trackid_v) ss2 << child << " " << std::flush;
-	ss2 << std::endl;
-	LARCV_INFO() << ss2.str();
-	LARCV_INFO() << "Above was supposed to be merged..." << std::endl;
+        ss2 << "  Children track IDs: " << std::flush;
+        for(auto const& child : grp.trackid_v) ss2 << child << " " << std::flush;
+        ss2 << std::endl;
+        LARCV_INFO() << ss2.str();
+        LARCV_INFO() << "Above was supposed to be merged..." << std::endl;
 
       }
       LARCV_INFO() << "... " << ctr << " particles" << std::endl;
@@ -2153,12 +2138,12 @@ namespace larcv {
       auto const& vs0  = main_vs[index];
       auto const& vs1  = lowe_vs[index];
       LARCV_INFO() << "Particle ID " << part.id() << " Track ID " << part.track_id() << " PDG " << part.pdg_code()
-		   << " " << part.creation_process() << " ... " << part.energy_init() << " MeV => " << part.energy_deposit() << " MeV "
-		   << grp.trackid_v.size() << " children " << vs0.size() << " (" << vs1.size() << ") voxels" << std::endl;
+       << " " << part.creation_process() << " ... " << part.energy_init() << " MeV => " << part.energy_deposit() << " MeV "
+       << grp.trackid_v.size() << " children " << vs0.size() << " (" << vs1.size() << ") voxels" << std::endl;
       LARCV_INFO() << "  Parent TrackID " << part.parent_track_id() << " PartID " << part.parent_id()
-		   << " PDG " << part.parent_pdg_code() << " " << part.parent_creation_process()
-		   << " Ancestor TrackID " << part.ancestor_track_id()
-		   << " PDG " << part.ancestor_pdg_code() << " " << part.ancestor_creation_process() << std::endl;
+       << " PDG " << part.parent_pdg_code() << " " << part.parent_creation_process()
+       << " Ancestor TrackID " << part.ancestor_track_id()
+       << " PDG " << part.ancestor_pdg_code() << " " << part.ancestor_creation_process() << std::endl;
       LARCV_INFO() << "  Group ID: " << part.group_id() << std::endl;
       std::stringstream ss1,ss2;
 
@@ -2180,63 +2165,63 @@ namespace larcv {
     // Check the validity of particle id, group id
     if(_check_particle_validity) {
       for(size_t part_index=0; part_index < part_v.size(); ++part_index) {
-	auto const& part = part_v[part_index];
-	if(part.id() != part_index) {
-	  LARCV_CRITICAL() << "Particle index " << part_index << " holds particle w/ an ID " << part.id() << std::endl
-			   << part.dump() << std::endl;
-	  throw std::exception();
-	}
-	if(part.parent_id() != larcv::kINVALID_INSTANCEID && part.parent_id() >= part_v.size()) {
-	  LARCV_CRITICAL() << "Particle index " << part_index
-			   << " holds particle w/ an invalid parent ID " << part.parent_id() << std::endl
-			   << part.dump() << std::endl
-			   << part_grp_v[part.parent_track_id()].part.dump() << std::endl;
-	  throw std::exception();
-	}
-	if(part.group_id() == larcv::kINVALID_INSTANCEID || part.group_id() >= part_v.size()) {
-	  LARCV_CRITICAL() << "Particle index " << part_index
-			   << " holds particle w/ an invalid group ID " << part.group_id() << std::endl
-			   << part.dump() << std::endl;
-	  throw std::exception();
-	}
-	if(part.parent_id() == part.id() || part.parent_id() == larcv::kINVALID_INSTANCEID) continue;
-	bool found=false;
-	for(auto const& child : part_v[part.parent_id()].children_id()) {
-	  if(child == part_index) { found = true; break; }
-	}
-	if(!found) {
-	  LARCV_WARNING() << "Particle index " << part_index
-			  << " not in the list of the parent's children (fixing)" << std::endl;
-	  auto children = part_v[part.parent_id()].children_id();
-	  children.push_back(part_index);
-	  part_v[part.parent_id()].children_id(children);
-	}
+        auto const& part = part_v[part_index];
+        if(part.id() != part_index) {
+          LARCV_CRITICAL() << "Particle index " << part_index << " holds particle w/ an ID " << part.id() << std::endl
+               << part.dump() << std::endl;
+          throw std::exception();
+        }
+        if(part.parent_id() != larcv::kINVALID_INSTANCEID && part.parent_id() >= part_v.size()) {
+          LARCV_CRITICAL() << "Particle index " << part_index
+               << " holds particle w/ an invalid parent ID " << part.parent_id() << std::endl
+               << part.dump() << std::endl
+               << part_grp_v[part.parent_track_id()].part.dump() << std::endl;
+          throw std::exception();
+        }
+        if(part.group_id() == larcv::kINVALID_INSTANCEID || part.group_id() >= part_v.size()) {
+          LARCV_CRITICAL() << "Particle index " << part_index
+               << " holds particle w/ an invalid group ID " << part.group_id() << std::endl
+               << part.dump() << std::endl;
+          throw std::exception();
+        }
+        if(part.parent_id() == part.id() || part.parent_id() == larcv::kINVALID_INSTANCEID) continue;
+        bool found=false;
+        for(auto const& child : part_v[part.parent_id()].children_id()) {
+          if(child == part_index) { found = true; break; }
+        }
+        if(!found) {
+          LARCV_WARNING() << "Particle index " << part_index
+              << " not in the list of the parent's children (fixing)" << std::endl;
+          auto children = part_v[part.parent_id()].children_id();
+          children.push_back(part_index);
+          part_v[part.parent_id()].children_id(children);
+        }
       }
     }
 
     // validate dedx lenth
     if(_store_dedx) {
       if(event_cluster->size() != event_dedx->size()) {
-	LARCV_CRITICAL() << "Energy v.s. dE/dX cluster count mismatch "
-			 << event_cluster->size() << " v.s. " << event_dedx->size() << std::endl;
-	throw larbys();
+        LARCV_CRITICAL() << "Energy v.s. dE/dX cluster count mismatch "
+             << event_cluster->size() << " v.s. " << event_dedx->size() << std::endl;
+        throw larbys();
       }
       if(event_cluster_he->size() != event_dedx_he->size()) {
-	LARCV_CRITICAL() << "Energy v.s. dE/dX (HighE) cluster count mismatch "
-			 << event_cluster_he->size() << " v.s. " << event_dedx_he->size() << std::endl;
-	throw larbys();
+        LARCV_CRITICAL() << "Energy v.s. dE/dX (HighE) cluster count mismatch "
+             << event_cluster_he->size() << " v.s. " << event_dedx_he->size() << std::endl;
+        throw larbys();
       }
       if(event_cluster_le->size() != event_dedx_le->size()) {
-	LARCV_CRITICAL() << "Energy v.s. dE/dX (LowE) cluster count mismatch "
-			 << event_cluster_le->size() << " v.s. " << event_dedx_le->size() << std::endl;
-	throw larbys();
+        LARCV_CRITICAL() << "Energy v.s. dE/dX (LowE) cluster count mismatch "
+             << event_cluster_le->size() << " v.s. " << event_dedx_le->size() << std::endl;
+        throw larbys();
       }
       for(size_t i=0; i<event_cluster->size(); ++i) {
-	if(event_cluster->as_vector()[i].size() != event_dedx->as_vector()[i].size()) {
-	  LARCV_CRITICAL() << "Energy v.s. dE/dX cluster " << i << " has mismatch voxel count "
-			   << event_cluster->as_vector()[i].size() << " v.s. " << event_dedx->as_vector()[i].size() <<std::endl;
-	  throw larbys();
-	}
+        if(event_cluster->as_vector()[i].size() != event_dedx->as_vector()[i].size()) {
+          LARCV_CRITICAL() << "Energy v.s. dE/dX cluster " << i << " has mismatch voxel count "
+               << event_cluster->as_vector()[i].size() << " v.s. " << event_dedx->as_vector()[i].size() <<std::endl;
+          throw larbys();
+        }
       }
     }
 
@@ -2266,7 +2251,7 @@ namespace larcv {
       auto& semantic2d = semantic2d_vs_v[plane_idx];
       auto& vsa2d_le   = vsa2d_le_v[plane_idx];
       for(auto const& vs : vsa2d_le.as_vector()) {
-	for(auto const& vox : vs.as_vector()) semantic2d.emplace(vox.id(),(float)(larcv::kShapeLEScatter),false);
+        for(auto const& vox : vs.as_vector()) semantic2d.emplace(vox.id(),(float)(larcv::kShapeLEScatter),false);
       }
     }
 
@@ -2275,30 +2260,30 @@ namespace larcv {
       auto const& vs  = event_cluster_he->as_vector()[index];
       size_t semantic = (size_t)(part_v[index].shape());
       for(auto const& vox : vs.as_vector()) {
-	auto const& prev = semantic_vs.find(vox.id());
-	if(prev.id() == larcv::kINVALID_VOXELID) {
-	  semantic_vs.emplace(vox.id(),semantic,false);
-	  cid_vs.emplace(vox.id(),index,false);
-	}
-	else {
-	  size_t prioritized_semantic = this->SemanticPriority(prev.value(),semantic);
-	  if(prioritized_semantic != prev.value()) {
-	    semantic_vs.emplace(vox.id(),semantic,false);
-	    cid_vs.emplace(vox.id(),index,false);
-	  }
-	}
+        auto const& prev = semantic_vs.find(vox.id());
+        if(prev.id() == larcv::kINVALID_VOXELID) {
+          semantic_vs.emplace(vox.id(),semantic,false);
+          cid_vs.emplace(vox.id(),index,false);
+        }
+        else {
+          size_t prioritized_semantic = this->SemanticPriority(prev.value(),semantic);
+          if(prioritized_semantic != prev.value()) {
+            semantic_vs.emplace(vox.id(),semantic,false);
+            cid_vs.emplace(vox.id(),index,false);
+          }
+        }
       }
       for(size_t plane_id=0; plane_id < _valid_nplanes; ++plane_id) {
-	auto& semantic2d_vs = semantic2d_vs_v[plane_id];
-	auto const& vsa2d_he = vsa2d_he_v[plane_id];
-	auto const& vs2d = vsa2d_he.as_vector()[index];
-	for(auto const& vox : vs2d.as_vector()) {
-	  auto const& prev = semantic2d_vs.find(vox.id());
-	  if(prev.id() == larcv::kINVALID_VOXELID)
-	    semantic2d_vs.emplace(vox.id(),semantic,false);
-	  else
-	    semantic2d_vs.emplace(vox.id(),this->SemanticPriority(((size_t)(prev.value())),semantic),false);
-	}
+        auto& semantic2d_vs = semantic2d_vs_v[plane_id];
+        auto const& vsa2d_he = vsa2d_he_v[plane_id];
+        auto const& vs2d = vsa2d_he.as_vector()[index];
+        for(auto const& vox : vs2d.as_vector()) {
+          auto const& prev = semantic2d_vs.find(vox.id());
+          if(prev.id() == larcv::kINVALID_VOXELID)
+            semantic2d_vs.emplace(vox.id(),semantic,false);
+          else
+            semantic2d_vs.emplace(vox.id(),this->SemanticPriority(((size_t)(prev.value())),semantic),false);
+        }
       }
     }
     // store
@@ -2309,37 +2294,37 @@ namespace larcv {
     for(size_t cryo_id=0; cryo_id<_scan.size(); ++cryo_id) {
       auto const& tpcs = _scan[cryo_id];
       for(size_t tpc_id=0; tpc_id<tpcs.size(); ++tpc_id) {
-	auto const& planes = tpcs[tpc_id];
-	for(size_t plane_id=0; plane_id<planes.size(); ++plane_id) {
-	  auto const& idx = planes.at(plane_id);
-	  if(idx < 0) continue;
-	  if(idx >= (int)(_meta2d_v.size())) {
-	    LARCV_CRITICAL() <<idx << "Unexpected: " << _meta2d_v.size() << " " << semantic2d_vs_v.size() << std::endl;
-	    throw larbys();
-	  }
-	  auto meta2d = _meta2d_v[idx];
-	  std::string suffix = "_" + std::to_string(cryo_id) + "_" + std::to_string(tpc_id) + "_" + std::to_string(plane_id);
-	  std::string output_producer = _output_label + "_semantics2d" + suffix;
-	  auto semantic2d_output = (larcv::EventSparseTensor2D*)(mgr.get_data("sparse2d",output_producer));
-	  semantic2d_output->emplace(std::move(semantic2d_vs_v[idx]),std::move(meta2d));
-	  output_producer = _output_label + suffix;
-	  auto& cluster2d_output  = mgr.get_data<larcv::EventClusterPixel2D>(output_producer);
-	  cluster2d_output.emplace(std::move(vsa2d_v[idx]));
+  auto const& planes = tpcs[tpc_id];
+  for(size_t plane_id=0; plane_id<planes.size(); ++plane_id) {
+    auto const& idx = planes.at(plane_id);
+    if(idx < 0) continue;
+    if(idx >= (int)(_meta2d_v.size())) {
+      LARCV_CRITICAL() <<idx << "Unexpected: " << _meta2d_v.size() << " " << semantic2d_vs_v.size() << std::endl;
+      throw larbys();
+    }
+    auto meta2d = _meta2d_v[idx];
+    std::string suffix = "_" + std::to_string(cryo_id) + "_" + std::to_string(tpc_id) + "_" + std::to_string(plane_id);
+    std::string output_producer = _output_label + "_semantics2d" + suffix;
+    auto semantic2d_output = (larcv::EventSparseTensor2D*)(mgr.get_data("sparse2d",output_producer));
+    semantic2d_output->emplace(std::move(semantic2d_vs_v[idx]),std::move(meta2d));
+    output_producer = _output_label + suffix;
+    auto& cluster2d_output  = mgr.get_data<larcv::EventClusterPixel2D>(output_producer);
+    cluster2d_output.emplace(std::move(vsa2d_v[idx]));
 
-	  output_producer = _output_label + "_he" + suffix;
-	  auto& cluster2d_he_output  = mgr.get_data<larcv::EventClusterPixel2D>(output_producer);
-	  cluster2d_he_output.emplace(std::move(vsa2d_he_v[idx]));
+    output_producer = _output_label + "_he" + suffix;
+    auto& cluster2d_he_output  = mgr.get_data<larcv::EventClusterPixel2D>(output_producer);
+    cluster2d_he_output.emplace(std::move(vsa2d_he_v[idx]));
 
-	  output_producer = _output_label + "_le" + suffix;
-	  auto& cluster2d_le_output  = mgr.get_data<larcv::EventClusterPixel2D>(output_producer);
-	  cluster2d_le_output.emplace(std::move(vsa2d_le_v[idx]));
+    output_producer = _output_label + "_le" + suffix;
+    auto& cluster2d_le_output  = mgr.get_data<larcv::EventClusterPixel2D>(output_producer);
+    cluster2d_le_output.emplace(std::move(vsa2d_le_v[idx]));
 
-	  output_producer = _output_label + "_leftover" + suffix;
-	  auto& tensor2d_leftover  = mgr.get_data<larcv::EventSparseTensor2D>(output_producer);
-	  meta2d = _meta2d_v[idx];
-	  tensor2d_leftover.emplace(std::move(leftover2d_vs[idx]),std::move(meta2d));
-	  //std::cout<<cryo_id<<" "<<tpc_id<<" "<<plane_id<<" ... " << semantic2d_output.as_vector().size() << " " << semantic2d_output.as_vector().front().meta().id() <<std::endl;
-	}
+    output_producer = _output_label + "_leftover" + suffix;
+    auto& tensor2d_leftover  = mgr.get_data<larcv::EventSparseTensor2D>(output_producer);
+    meta2d = _meta2d_v[idx];
+    tensor2d_leftover.emplace(std::move(leftover2d_vs[idx]),std::move(meta2d));
+    //std::cout<<cryo_id<<" "<<tpc_id<<" "<<plane_id<<" ... " << semantic2d_output.as_vector().size() << " " << semantic2d_output.as_vector().front().meta().id() <<std::endl;
+  }
       }
     }
 
@@ -2362,20 +2347,20 @@ namespace larcv {
     int parent_trackid = larmcp_v[trackid2index[trackid]].Mother();
     std::set<int> accessed;
     while(parent_trackid > 0 &&
-	  (size_t)(parent_trackid) < trackid2index.size() &&
-	  trackid2index[parent_trackid] >= 0) {
+    (size_t)(parent_trackid) < trackid2index.size() &&
+    trackid2index[parent_trackid] >= 0) {
       if(accessed.find(parent_trackid) != accessed.end()) {
-	LARCV_CRITICAL() << "LOOP-LOGIC-ERROR for ParentTrackIDs for track id " << trackid << std::endl;
-	for(size_t parent_idx=0; parent_idx<result.size(); ++parent_idx) {
-	  auto const& parent_trackid = result[parent_idx];
-	  auto const& mcp = larmcp_v.at(trackid2index.at(parent_trackid));
-	  LARCV_CRITICAL() << "Parent "    << parent_idx
-			   << " Track ID " << mcp.TrackId() //<< " (" << parent_trackid << ")"
-			   << " PDG "      << mcp.PdgCode()
-			   << " Process "  << mcp.Process()
-			   << " Mother "   << mcp.Mother() << std::endl;
-	}
-	throw std::exception();
+        LARCV_CRITICAL() << "LOOP-LOGIC-ERROR for ParentTrackIDs for track id " << trackid << std::endl;
+        for(size_t parent_idx=0; parent_idx<result.size(); ++parent_idx) {
+          auto const& parent_trackid = result[parent_idx];
+          auto const& mcp = larmcp_v.at(trackid2index.at(parent_trackid));
+          LARCV_CRITICAL() << "Parent "    << parent_idx
+               << " Track ID " << mcp.TrackId() //<< " (" << parent_trackid << ")"
+               << " PDG "      << mcp.PdgCode()
+               << " Process "  << mcp.Process()
+               << " Mother "   << mcp.Mother() << std::endl;
+        }
+        throw std::exception();
       }
 
       auto const& parent = larmcp_v[trackid2index[parent_trackid]];
@@ -2389,8 +2374,8 @@ namespace larcv {
 
   std::vector<unsigned int>
   SuperaMCParticleCluster::ParentShowerTrackIDs(size_t trackid,
-						const std::vector<supera::ParticleGroup>& part_grp_v,
-						bool include_lescatter) const
+            const std::vector<supera::ParticleGroup>& part_grp_v,
+            bool include_lescatter) const
   {
     auto parents = this->ParentTrackIDs(trackid);
     std::vector<unsigned int> result;
@@ -2404,28 +2389,28 @@ namespace larcv {
       if(!grp.valid) continue;
 
       if(grp.shape() == larcv::kShapeTrack ||
-	 grp.shape() == larcv::kShapeUnknown)
-	break;
+   grp.shape() == larcv::kShapeUnknown)
+  break;
 
       if(grp.shape() == larcv::kShapeMichel ||
-	 grp.shape() == larcv::kShapeShower ||
-	 grp.shape() == larcv::kShapeDelta  ||
-	 (grp.shape() == larcv::kShapeLEScatter && include_lescatter))
-	 result.push_back(parent_id);
+   grp.shape() == larcv::kShapeShower ||
+   grp.shape() == larcv::kShapeDelta  ||
+   (grp.shape() == larcv::kShapeLEScatter && include_lescatter))
+   result.push_back(parent_id);
     }
     return result;
   }
 
   void SuperaMCParticleCluster::DumpHierarchy(size_t trackid,
-					      const std::vector<supera::ParticleGroup>& part_grp_v) const
+                const std::vector<supera::ParticleGroup>& part_grp_v) const
   {
     assert(trackid < part_grp_v.size());
 
     auto const& grp = part_grp_v[trackid];
     std::cout << std::endl << "#### Dumping particle record for track id "
-	      << grp.part.track_id() << " ####" << std::endl;
+        << grp.part.track_id() << " ####" << std::endl;
     std::cout << "id " << grp.part.id() << " from " << grp.part.parent_id() << std::endl
-	      << "children: " << std::flush;
+        << "children: " << std::flush;
     for(auto const& child : grp.part.children_id()) std::cout << child << " " << std::flush;
     std::cout << std::endl;
     std::cout << grp.part.dump() << std::endl;
@@ -2486,15 +2471,15 @@ namespace larcv {
     for(auto const& vox1 : vs1.as_vector()) {
       meta.id_to_xyz_index(vox1.id(), ix1, iy1, iz1);
       for(auto const& vox2 : vs2.as_vector()) {
-	meta.id_to_xyz_index(vox2.id(), ix2, iy2, iz2);
-	if(ix1>ix2) diffx = ix1-ix2; else diffx = ix2-ix1;
-	if(iy1>iy2) diffy = iy1-iy2; else diffy = iy2-iy1;
-	if(iz1>iz2) diffz = iz1-iz2; else diffz = iz2-iz1;
-	touching = diffx<=_touch_threshold && diffy<=_touch_threshold && diffz <=_touch_threshold;
-	if(touching) {
-	  //std::cout<<"Touching ("<<ix1<<","<<iy1<<","<<iz1<<") ("<<ix2<<","<<iy2<<","<<iz2<<")"<<std::endl;
-	  break;
-	}
+        meta.id_to_xyz_index(vox2.id(), ix2, iy2, iz2);
+        if(ix1>ix2) diffx = ix1-ix2; else diffx = ix2-ix1;
+        if(iy1>iy2) diffy = iy1-iy2; else diffy = iy2-iy1;
+        if(iz1>iz2) diffz = iz1-iz2; else diffz = iz2-iz1;
+        touching = diffx<=_touch_threshold && diffy<=_touch_threshold && diffz <=_touch_threshold;
+        if(touching) {
+          //std::cout<<"Touching ("<<ix1<<","<<iy1<<","<<iz1<<") ("<<ix2<<","<<iy2<<","<<iz2<<")"<<std::endl;
+          break;
+        }
       }
       if(touching) break;
     }
@@ -2514,11 +2499,11 @@ namespace larcv {
     for(auto const& vox1 : vs1.as_vector()) {
       meta.index_to_rowcol(vox1.id(), iy1, ix1);
       for(auto const& vox2 : vs2.as_vector()) {
-	meta.index_to_rowcol(vox2.id(), iy2, ix2);
-	if(ix1>ix2) diffx = ix1-ix2; else diffx = ix2-ix1;
-	if(iy1>iy2) diffy = iy1-iy2; else diffy = iy2-iy1;
-	touching = diffx<=_touch_threshold2d && diffy<=_touch_threshold2d;
-	if(touching) break;
+        meta.index_to_rowcol(vox2.id(), iy2, ix2);
+        if(ix1>ix2) diffx = ix1-ix2; else diffx = ix2-ix1;
+        if(iy1>iy2) diffy = iy1-iy2; else diffy = iy2-iy1;
+        touching = diffx<=_touch_threshold2d && diffy<=_touch_threshold2d;
+        if(touching) break;
       }
       if(touching) break;
     }

--- a/SuperaMCParticleCluster.h
+++ b/SuperaMCParticleCluster.h
@@ -55,13 +55,13 @@ namespace larcv {
 
     std::vector<supera::ParticleGroup> CreateParticleGroups();
 
-    void AnalyzeSimEnergyDeposit(const larcv::Voxel3DMeta& meta,
+    template<typename sed_type> void AnalyzeSimEnergyDeposit(const larcv::Voxel3DMeta& meta,
 				 std::vector<supera::ParticleGroup>& part_grp_v,
          larcv::IOManager& mgr);
     void AnalyzeSimChannel(const larcv::Voxel3DMeta& meta,
 			   std::vector<supera::ParticleGroup>& part_grp_v,
 			   larcv::IOManager& mgr);
-    void AnalyzeFirstLastStep(const larcv::Voxel3DMeta& meta,
+    template<typename sed_type> void AnalyzeFirstLastStep(const larcv::Voxel3DMeta& meta,
 			      std::vector<supera::ParticleGroup>& part_grp_v);
     void MergeShowerTouchingLEScatter(const larcv::Voxel3DMeta& meta,
 				      std::vector<supera::ParticleGroup>& part_grp_v);
@@ -101,6 +101,7 @@ namespace larcv {
     double _edep_threshold;
     bool _use_true_pos;
     bool _use_sed;
+		bool _use_sed_lite;
     bool _check_particle_validity;
     int  _projection_id;
     bool _merge_shower_delta;

--- a/SuperaMCParticleCluster.h
+++ b/SuperaMCParticleCluster.h
@@ -110,6 +110,7 @@ namespace larcv {
     std::vector<size_t> _semantic_priority;
     size_t _valid_nplanes;
     std::vector<larcv::ImageMeta> _meta2d_v;
+    bool _useOrigTrackID; ///< Whether to use origTrackID or trackID from SimChannel/SimEnergyDeposit
   };
 
   /**

--- a/SuperaOptical.cxx
+++ b/SuperaOptical.cxx
@@ -15,14 +15,18 @@ namespace larcv {
   void SuperaOptical::configure(const PSet& cfg)
   {
     SuperaBase::configure(cfg);
-		_opflash_producer_label_v = cfg.get<std::vector<std::string>>("OpFlashProducers");
-		_opflash_output_label_v   = cfg.get<std::vector<std::string>>("OpFlashOutputs");
+    _opflash_producer_label_v = cfg.get<std::vector<std::string>>("OpFlashProducers");
+    _opflash_output_label_v   = cfg.get<std::vector<std::string>>("OpFlashOutputs");
 
-		if (_opflash_producer_label_v.size() != _opflash_output_label_v.size()) {
-			LARCV_CRITICAL() << "Producer and output labels need to be the same size" << std::endl;
-			throw larbys();
-		}
-	}
+    if (_opflash_producer_label_v.size() != _opflash_output_label_v.size()) {
+      LARCV_CRITICAL() << "Producer and output labels need to be the same size" << std::endl;
+      throw larbys();
+    }
+
+    for (auto const& label : _opflash_producer_label_v)
+      if (!label.empty())
+        Request(supera::LArDataType_t::kLArOpFlash_t, label);
+  }
 
   void SuperaOptical::initialize()
   {
@@ -33,44 +37,45 @@ namespace larcv {
   {
     SuperaBase::process(mgr);
 
-		auto const *ev = GetEvent();
+    auto const *ev = GetEvent();
 
-		for (size_t label_idx = 0; label_idx < _opflash_output_label_v.size(); ++label_idx) {
-			std::string _opflash_output_label = _opflash_output_label_v[label_idx];
-			std::string _opflash_producer_label = _opflash_producer_label_v[label_idx];
+    for (size_t label_idx = 0; label_idx < _opflash_output_label_v.size(); ++label_idx) {
+      std::string _opflash_output_label = _opflash_output_label_v[label_idx];
+      std::string _opflash_producer_label = _opflash_producer_label_v[label_idx];
 
-			auto& opflash_tensor = mgr.get_data<larcv::EventFlash>(_opflash_output_label);
-			//auto const& meta = opflash_tensor.meta();
+      auto& opflash_tensor = mgr.get_data<larcv::EventFlash>(_opflash_output_label);
+      //auto const& meta = opflash_tensor.meta();
 
-			auto handle = ev->getValidHandle<std::vector<recob::OpFlash>>(_opflash_producer_label);
-			if (!handle.isValid()) {
-				LARCV_WARNING() << "No valid OpFlash found for label " << _opflash_producer_label << std::endl;
-				return false;
-			}
+      auto handle = ev->getValidHandle<std::vector<supera::LArOpFlash_t>>(_opflash_producer_label);
+      if (!handle.isValid()) {
+        LARCV_WARNING() << "No valid OpFlash found for label " << _opflash_producer_label << std::endl;
+        return false;
+      }
 
-			auto const & flashes = *handle;
-			std::vector<larcv::Flash> fset;
-			for (size_t idx = 0; idx < flashes.size(); ++idx) {
-				auto const& flash = flashes[idx];
+      auto const & flashes = *handle;
 
-				larcv::Flash larcv_flash(flash.Time(), flash.TimeWidth(), flash.AbsTime(), flash.Frame(),
-																 flash.PEs(),
-																 flash.InBeamFrame(), flash.OnBeamTime(), flash.FastToTotal(),
-																 flash.XCenter(), flash.XWidth(),
-																 flash.YCenter(), flash.YWidth(),
-																 flash.ZCenter(), flash.ZWidth(),
-																 flash.WireCenters(),
-																 flash.WireWidths(),
-																 idx);
-				fset.push_back(larcv_flash);
-			}
+      std::vector<larcv::Flash> fset;
+      for (size_t idx = 0; idx < flashes.size(); ++idx) {
+        auto const& flash = flashes[idx];
+
+        larcv::Flash larcv_flash(flash.Time(), flash.TimeWidth(), flash.AbsTime(), flash.Frame(),
+                                 flash.PEs(),
+                                 flash.InBeamFrame(), flash.OnBeamTime(), flash.FastToTotal(),
+                                 flash.XCenter(), flash.XWidth(),
+                                 flash.YCenter(), flash.YWidth(),
+                                 flash.ZCenter(), flash.ZWidth(),
+                                 flash.WireCenters(),
+                                 flash.WireWidths(),
+                                 idx);
+        fset.push_back(larcv_flash);
+      }
 
 
-			opflash_tensor.emplace(std::move(fset));
-		}
-		return true;
+      opflash_tensor.emplace(std::move(fset));
+    }
+    return true;
 
-	}
+  }
 
   void SuperaOptical::finalize()
   {}

--- a/SuperaOptical.cxx
+++ b/SuperaOptical.cxx
@@ -1,0 +1,78 @@
+#ifndef __SUPERAOPTICAL_CXX__
+#define __SUPERAOPTICAL_CXX__
+
+#include "SuperaOptical.h"
+#include "larcv/core/DataFormat/EventFlash.h"
+
+namespace larcv {
+
+  static SuperaOpticalProcessFactory __global_SuperaOpticalProcessFactory__;
+
+  SuperaOptical::SuperaOptical(const std::string name)
+    : SuperaBase(name)
+  {}
+
+  void SuperaOptical::configure(const PSet& cfg)
+  {
+    SuperaBase::configure(cfg);
+		_opflash_producer_label_v = cfg.get<std::vector<std::string>>("OpFlashProducers");
+		_opflash_output_label_v   = cfg.get<std::vector<std::string>>("OpFlashOutputs");
+
+		if (_opflash_producer_label_v.size() != _opflash_output_label_v.size()) {
+			LARCV_CRITICAL() << "Producer and output labels need to be the same size" << std::endl;
+			throw larbys();
+		}
+	}
+
+  void SuperaOptical::initialize()
+  {
+    SuperaBase::initialize();
+  }
+
+  bool SuperaOptical::process(IOManager& mgr)
+  {
+    SuperaBase::process(mgr);
+
+		auto const *ev = GetEvent();
+
+		for (size_t label_idx = 0; label_idx < _opflash_output_label_v.size(); ++label_idx) {
+			std::string _opflash_output_label = _opflash_output_label_v[label_idx];
+			std::string _opflash_producer_label = _opflash_producer_label_v[label_idx];
+
+			auto& opflash_tensor = mgr.get_data<larcv::EventFlash>(_opflash_output_label);
+			//auto const& meta = opflash_tensor.meta();
+
+			auto handle = ev->getValidHandle<std::vector<recob::OpFlash>>(_opflash_producer_label);
+			if (!handle.isValid()) {
+				LARCV_WARNING() << "No valid OpFlash found for label " << _opflash_producer_label << std::endl;
+				return false;
+			}
+
+			auto const & flashes = *handle;
+			std::vector<larcv::Flash> fset;
+			for (size_t idx = 0; idx < flashes.size(); ++idx) {
+				auto const& flash = flashes[idx];
+
+				larcv::Flash larcv_flash(flash.Time(), flash.TimeWidth(), flash.AbsTime(), flash.Frame(),
+																 flash.PEs(),
+																 flash.InBeamFrame(), flash.OnBeamTime(), flash.FastToTotal(),
+																 flash.XCenter(), flash.XWidth(),
+																 flash.YCenter(), flash.YWidth(),
+																 flash.ZCenter(), flash.ZWidth(),
+																 flash.WireCenters(),
+																 flash.WireWidths(),
+																 idx);
+				fset.push_back(larcv_flash);
+			}
+
+
+			opflash_tensor.emplace(std::move(fset));
+		}
+		return true;
+
+	}
+
+  void SuperaOptical::finalize()
+  {}
+}
+#endif

--- a/SuperaOptical.h
+++ b/SuperaOptical.h
@@ -1,0 +1,67 @@
+/**
+ * \file SuperaOptical.h
+ *
+ * \ingroup Package_Name
+ *
+ * \brief Class def header for a class SuperaOptical
+ *
+ * @author Temigo
+ */
+
+/** \addtogroup Package_Name
+
+    @{*/
+#ifndef __SUPERAOPTICAL_H__
+#define __SUPERAOPTICAL_H__
+#include "SuperaBase.h"
+#include <vector>
+
+namespace larcv {
+
+  /**
+     \class ProcessBase
+     User defined class SuperaOptical ... these comments are used to generate
+     doxygen documentation!
+  */
+  class SuperaOptical : public SuperaBase {
+
+	public:
+		/// Default constructor
+		SuperaOptical(const std::string name = "SuperaOptical");
+
+		/// Default destructor
+		~SuperaOptical() {}
+
+    void configure(const PSet&);
+
+    void initialize();
+
+    bool process(IOManager& mgr);
+
+    void finalize();
+
+	private:
+		std::vector<std::string> _opflash_producer_label_v;
+		std::vector<std::string> _opflash_output_label_v;
+
+	};
+
+  /**
+     \class larcv::SuperaOpticalFactory
+     \brief A concrete factory class for larcv::SuperaOptical
+  */
+  class SuperaOpticalProcessFactory : public ProcessFactoryBase {
+  public:
+    /// ctor
+    SuperaOpticalProcessFactory() {
+        ProcessFactory::get().add_factory("SuperaOptical", this);
+    }
+    /// dtor
+    ~SuperaOpticalProcessFactory() {}
+    /// creation method
+    ProcessBase* create(const std::string instance_name) { return new SuperaOptical(instance_name); }
+  };
+
+}
+#endif
+/** @} */ // end of doxygen group

--- a/SuperaOptical.h
+++ b/SuperaOptical.h
@@ -25,12 +25,12 @@ namespace larcv {
   */
   class SuperaOptical : public SuperaBase {
 
-	public:
-		/// Default constructor
-		SuperaOptical(const std::string name = "SuperaOptical");
+  public:
+    /// Default constructor
+    SuperaOptical(const std::string name = "SuperaOptical");
 
-		/// Default destructor
-		~SuperaOptical() {}
+    /// Default destructor
+    ~SuperaOptical() {}
 
     void configure(const PSet&);
 
@@ -40,11 +40,11 @@ namespace larcv {
 
     void finalize();
 
-	private:
-		std::vector<std::string> _opflash_producer_label_v;
-		std::vector<std::string> _opflash_output_label_v;
+  private:
+    std::vector<std::string> _opflash_producer_label_v;
+    std::vector<std::string> _opflash_output_label_v;
 
-	};
+  };
 
   /**
      \class larcv::SuperaOpticalFactory

--- a/SuperaSimEnergyDeposit.cxx
+++ b/SuperaSimEnergyDeposit.cxx
@@ -69,16 +69,16 @@ namespace larcv {
 
 			larcv::Point3D pt;
 			VoxelID_t vox_id = meta.id(sedep.X(), sedep.Y(), sedep.Z());
+			int track_id = std::abs(sedep.TrackID());
 			if(vox_id == larcv::kINVALID_VOXELID || !_world_bounds.contains(sedep.X(),sedep.Y(),sedep.Z())) {
-	LARCV_DEBUG() << "Skipping sedep from track id " << sedep.TrackID()
+	LARCV_DEBUG() << "Skipping sedep from track id " << track_id
 					<< " E=" << sedep.Energy()
 					<< " pos=(" << sedep.X() << "," << sedep.Y() << "," << sedep.Z() << ")" << std::endl;
 	continue;
 			}
-			LARCV_DEBUG() << "Recording sedep from track id " << sedep.TrackID()
+			LARCV_DEBUG() << "Recording sedep from track id " << track_id
 				<< " E=" << sedep.Energy() << std::endl;
 			size_t cluster_idx = mcp_v.size();
-			int track_id = std::abs(sedep.TrackID());
 			if(track_id < (int)(part_idx_v.size()) && part_idx_v.at(track_id)>=0)
 	cluster_idx = part_idx_v.at(track_id);
 			assert(cluster_idx == event_de_v.as_vector().size());
@@ -110,16 +110,16 @@ namespace larcv {
 
 			larcv::Point3D pt;
 			VoxelID_t vox_id = meta.id(sedep.X(), sedep.Y(), sedep.Z());
+			int track_id = std::abs(sedep.TrackID());
 			if(vox_id == larcv::kINVALID_VOXELID || !_world_bounds.contains(sedep.X(),sedep.Y(),sedep.Z())) {
-	LARCV_DEBUG() << "Skipping sedep from track id " << sedep.TrackID()
+	LARCV_DEBUG() << "Skipping sedep from track id " << track_id
 					<< " E=" << sedep.Energy()
 					<< " pos=(" << sedep.X() << "," << sedep.Y() << "," << sedep.Z() << ")" << std::endl;
 	continue;
 			}
-			LARCV_DEBUG() << "Recording sedep from track id " << sedep.TrackID()
+			LARCV_DEBUG() << "Recording sedep from track id " << track_id
 				<< " E=" << sedep.Energy() << std::endl;
 			size_t cluster_idx = mcp_v.size();
-			int track_id = std::abs(sedep.TrackID());
 			if(track_id < (int)(part_idx_v.size()) && part_idx_v.at(track_id)>=0)
 	cluster_idx = part_idx_v.at(track_id);
 			assert(cluster_idx == event_de_v.as_vector().size());

--- a/SuperaSimEnergyDeposit.cxx
+++ b/SuperaSimEnergyDeposit.cxx
@@ -3,8 +3,6 @@
 
 #include "SuperaSimEnergyDeposit.h"
 #include "GenRandom.h"
-#include "larcv/core/DataFormat/EventParticle.h"
-#include "larcv/core/DataFormat/EventVoxel3D.h"
 
 namespace larcv {
 
@@ -24,6 +22,7 @@ namespace larcv {
     _store_dt = cfg.get<bool>("StoreDiffTime");
     _store_at = cfg.get<bool>("StoreAbsTime");
     _store_dedx = cfg.get<bool>("StoreDEDX");
+		_use_lite = cfg.get<bool>("UseSEDLite", false);
 
     auto cryostat_v   = cfg.get<std::vector<unsigned short> >("CryostatList");
     auto tpc_v        = cfg.get<std::vector<unsigned short> >("TPCList"     );
@@ -36,7 +35,7 @@ namespace larcv {
       auto const& t = tpc_v[idx];
       auto const& cryostat = geop->Cryostat(c);
       if(!cryostat.HasTPC(t)) {
-	LARCV_CRITICAL() << "Invalid TPCList: cryostat " << c 
+	LARCV_CRITICAL() << "Invalid TPCList: cryostat " << c
 			 << " does not contain tpc " << t << std::endl;
 	throw larbys();
       }
@@ -48,13 +47,120 @@ namespace larcv {
       if(max_pt.y < tpcabox.MaxY()) max_pt.y = tpcabox.MaxY();
       if(max_pt.z < tpcabox.MaxZ()) max_pt.z = tpcabox.MaxZ();
     }
-    _world_bounds.update(min_pt,max_pt); 
+    _world_bounds.update(min_pt,max_pt);
   }
 
   void SuperaSimEnergyDeposit::initialize()
   {
     SuperaBase::initialize();
   }
+
+	void SuperaSimEnergyDeposit::fill_sedep_v(
+			const std::vector<larcv::Particle> mcp_v,
+			std::vector<int>& part_idx_v,
+			larcv::Voxel3DMeta meta,
+			larcv::EventClusterVoxel3D& event_de_v
+			) {
+
+		auto const& sedep_v = LArData<supera::LArSimEnergyDepositLite_t>();
+		LARCV_INFO() << "Processing SimEnergyDeposit array: " << sedep_v.size() << std::endl;
+		for(size_t sedep_idx=0; sedep_idx<sedep_v.size(); ++sedep_idx) {
+			auto const& sedep = sedep_v.at(sedep_idx);
+
+			larcv::Point3D pt;
+			VoxelID_t vox_id = meta.id(sedep.X(), sedep.Y(), sedep.Z());
+			if(vox_id == larcv::kINVALID_VOXELID || !_world_bounds.contains(sedep.X(),sedep.Y(),sedep.Z())) {
+	LARCV_DEBUG() << "Skipping sedep from track id " << sedep.TrackID()
+					<< " E=" << sedep.Energy()
+					<< " pos=(" << sedep.X() << "," << sedep.Y() << "," << sedep.Z() << ")" << std::endl;
+	continue;
+			}
+			LARCV_DEBUG() << "Recording sedep from track id " << sedep.TrackID()
+				<< " E=" << sedep.Energy() << std::endl;
+			size_t cluster_idx = mcp_v.size();
+			int track_id = std::abs(sedep.TrackID());
+			if(track_id < (int)(part_idx_v.size()) && part_idx_v.at(track_id)>=0)
+	cluster_idx = part_idx_v.at(track_id);
+			assert(cluster_idx == event_de_v.as_vector().size());
+			LARCV_DEBUG() << "Cluster index: " << cluster_idx << " / " << event_de_v.as_vector().size() << std::endl;
+			float de = sedep.Energy();
+			//float at = sedep.T();
+
+			larcv::Voxel v(vox_id, de);
+			event_de_v.writeable_voxel_set(cluster_idx).add(v);
+		} // end for
+	}
+
+	void SuperaSimEnergyDeposit::fill_sedep_v(
+			const std::vector<larcv::Particle> mcp_v,
+			std::vector<int>& part_idx_v,
+			larcv::Voxel3DMeta meta,
+			larcv::EventClusterVoxel3D& event_de_v,
+			larcv::EventClusterVoxel3D* event_dq_v,
+			larcv::EventClusterVoxel3D* event_dp_v,
+			larcv::EventClusterVoxel3D* event_dx_v,
+			larcv::EventClusterVoxel3D* event_dt_v,
+			larcv::EventClusterVoxel3D* event_at_v,
+			larcv::EventClusterVoxel3D* event_dedx_v
+			) {
+		auto const& sedep_v = LArData<supera::LArSimEnergyDeposit_t>();
+		LARCV_INFO() << "Processing SimEnergyDeposit array: " << sedep_v.size() << std::endl;
+		for(size_t sedep_idx=0; sedep_idx<sedep_v.size(); ++sedep_idx) {
+			auto const& sedep = sedep_v.at(sedep_idx);
+
+			larcv::Point3D pt;
+			VoxelID_t vox_id = meta.id(sedep.X(), sedep.Y(), sedep.Z());
+			if(vox_id == larcv::kINVALID_VOXELID || !_world_bounds.contains(sedep.X(),sedep.Y(),sedep.Z())) {
+	LARCV_DEBUG() << "Skipping sedep from track id " << sedep.TrackID()
+					<< " E=" << sedep.Energy()
+					<< " pos=(" << sedep.X() << "," << sedep.Y() << "," << sedep.Z() << ")" << std::endl;
+	continue;
+			}
+			LARCV_DEBUG() << "Recording sedep from track id " << sedep.TrackID()
+				<< " E=" << sedep.Energy() << std::endl;
+			size_t cluster_idx = mcp_v.size();
+			int track_id = std::abs(sedep.TrackID());
+			if(track_id < (int)(part_idx_v.size()) && part_idx_v.at(track_id)>=0)
+	cluster_idx = part_idx_v.at(track_id);
+			assert(cluster_idx == event_de_v.as_vector().size());
+			LARCV_DEBUG() << "Cluster index: " << cluster_idx << " / " << event_de_v.as_vector().size() << std::endl;
+			float de = sedep.Energy();
+			float at = sedep.T();
+
+			larcv::Voxel v(vox_id, de);
+			event_de_v.writeable_voxel_set(cluster_idx).add(v);
+
+			// What follows is only to store extra information
+			// (afaik not used currently)
+
+			if (event_dq_v != nullptr) {
+				assert(event_dp_v != nullptr);
+				assert(event_dx_v != nullptr);
+				assert(event_dt_v != nullptr);
+				assert(event_at_v != nullptr);
+				assert(event_dedx_v != nullptr);
+
+				assert(cluster_idx == event_dq_v->as_vector().size());
+				assert(cluster_idx == event_dp_v->as_vector().size());
+				assert(cluster_idx == event_dx_v->as_vector().size());
+				assert(cluster_idx == event_dt_v->as_vector().size());
+				assert(cluster_idx == event_at_v->as_vector().size());
+				assert(cluster_idx == event_dedx_v->as_vector().size());
+				if(_store_dq) { v.set(vox_id, sedep.NumElectrons()); event_dq_v->writeable_voxel_set(cluster_idx).add(v); }
+				if(_store_dp) { v.set(vox_id, sedep.NumPhotons()); event_dp_v->writeable_voxel_set(cluster_idx).add(v); }
+				if(_store_dt) { v.set(vox_id, sedep.EndT() - sedep.StartT()); event_dt_v->writeable_voxel_set(cluster_idx).add(v); }
+				if(_store_dx || _store_dedx) { v.set(vox_id, sedep.StepLength()); event_dx_v->writeable_voxel_set(cluster_idx).add(v); }
+				if(_store_at) {
+					auto& cluster = event_at_v->writeable_voxel_set(cluster_idx);
+					auto const& vox = cluster.find(vox_id);
+					if(vox.id() == larcv::kINVALID_VOXELID)
+						cluster.emplace(vox_id, at, true);
+					else if(at < vox.value())
+						cluster.emplace(vox_id, at, false);
+				}
+			}
+		} //end for
+	} // end fill_sedep_v
 
   bool SuperaSimEnergyDeposit::process(IOManager& mgr)
   {
@@ -76,7 +182,7 @@ namespace larcv {
     */
     // List particles to be stored
     static std::vector<int> part_idx_v(1e6,-1);
-    std::fill(part_idx_v.begin(),part_idx_v.end(),-1);    
+    std::fill(part_idx_v.begin(),part_idx_v.end(),-1);
     auto const& mcp_v = mgr.get_data<larcv::EventParticle>(_particle_label).as_vector();
     LARCV_INFO() << "Processing larcv::EventParticle array: " << mcp_v.size() << std::endl;
     auto const& mcshower_v = LArData<supera::LArMCShower_t>();
@@ -124,7 +230,7 @@ namespace larcv {
     if(_store_dedx)
       { event_dedx_v = (larcv::EventClusterVoxel3D*)(mgr.get_data("cluster3d", _output_label + "_dedx"));
 	event_dedx_v->resize(mcp_v.size()+1); event_dedx_v->meta(meta); }
-    if( event_de_v.as_vector().size()  != (mcp_v.size() + 1) ) 
+    if( event_de_v.as_vector().size()  != (mcp_v.size() + 1) )
       { LARCV_ERROR() << "event_de_v size mismatch with mcp_v: " << event_de_v.as_vector().size()  << " vs. " << mcp_v.size(); throw std::exception(); }
     if( event_dx_v   && event_dx_v->as_vector().size() != (mcp_v.size() + 1) )
       { LARCV_ERROR() << "event_dx_v size mismatch with mcp_v: " << event_dx_v->as_vector().size() << " vs. " << mcp_v.size(); throw std::exception(); }
@@ -137,63 +243,33 @@ namespace larcv {
     if( event_at_v   && event_at_v->as_vector().size() != (mcp_v.size() + 1) )
       { LARCV_ERROR() << "event_at_v size mismatch with mcp_v: " << event_at_v->as_vector().size() << " vs. " << mcp_v.size(); throw std::exception(); }
     if( event_dedx_v && event_dedx_v->as_vector().size() != (mcp_v.size() + 1) )
-      { LARCV_ERROR() << "event_dedx_v size mismatch with mcp_v: " << event_dedx_v->as_vector().size() << " vs. " << mcp_v.size(); throw std::exception(); }    
+      { LARCV_ERROR() << "event_dedx_v size mismatch with mcp_v: " << event_dedx_v->as_vector().size() << " vs. " << mcp_v.size(); throw std::exception(); }
     // Register particle energy deposition coordinates
-    auto const& sedep_v = LArData<supera::LArSimEnergyDeposit_t>();
-    LARCV_INFO() << "Processing SimEnergyDeposit array: " << sedep_v.size() << std::endl;
-    std::vector<int> store_idx_v;
-    store_idx_v.reserve(sedep_v.size());
-    for(size_t sedep_idx=0; sedep_idx<sedep_v.size(); ++sedep_idx) {
-      auto const& sedep = sedep_v.at(sedep_idx);
 
-      larcv::Point3D pt;
-      VoxelID_t vox_id = meta.id(sedep.X(), sedep.Y(), sedep.Z());
-      if(vox_id == larcv::kINVALID_VOXELID || !_world_bounds.contains(sedep.X(),sedep.Y(),sedep.Z())) {
-	LARCV_DEBUG() << "Skipping sedep from track id " << sedep.TrackID() 
-		      << " E=" << sedep.Energy()
-		      << " pos=(" << sedep.X() << "," << sedep.Y() << "," << sedep.Z() << ")" << std::endl;
-	continue;
-      }
-      LARCV_DEBUG() << "Recording sedep from track id " << sedep.TrackID() 
-		    << " E=" << sedep.Energy() << std::endl;
-      size_t cluster_idx = mcp_v.size();
-      int track_id = std::abs(sedep.TrackID());
-      if(track_id < (int)(part_idx_v.size()) && part_idx_v.at(track_id)>=0)
-	cluster_idx = part_idx_v.at(track_id);
-      assert(cluster_idx == event_de_v.as_vector().size());
-      assert(cluster_idx == event_dq_v->as_vector().size());
-      assert(cluster_idx == event_dp_v->as_vector().size());
-      assert(cluster_idx == event_dx_v->as_vector().size());
-      assert(cluster_idx == event_dt_v->as_vector().size());
-      assert(cluster_idx == event_at_v->as_vector().size());
-      assert(cluster_idx == event_dedx_v->as_vector().size());
-      LARCV_DEBUG() << "Cluster index: " << cluster_idx << " / " << event_de_v.as_vector().size() << std::endl;
-      float de = sedep.Energy();
-      float dx = sedep.StepLength();
-      float dq = sedep.NumElectrons();
-      float dp = sedep.NumPhotons();
-      float at = sedep.T();
-      float dt = sedep.EndT() - sedep.StartT();
-      
-      larcv::Voxel v(vox_id, de);
-      event_de_v.writeable_voxel_set(cluster_idx).add(v);
-
-      if(_store_dq) { v.set(vox_id, dq); event_dq_v->writeable_voxel_set(cluster_idx).add(v); }
-      if(_store_dp) { v.set(vox_id, dp); event_dp_v->writeable_voxel_set(cluster_idx).add(v); }
-      if(_store_dt) { v.set(vox_id, dt); event_dt_v->writeable_voxel_set(cluster_idx).add(v); }
-      if(_store_dx || _store_dedx) { v.set(vox_id, dx); event_dx_v->writeable_voxel_set(cluster_idx).add(v); }
-      if(_store_at) {
-	auto& cluster = event_at_v->writeable_voxel_set(cluster_idx);
-	auto const& vox = cluster.find(vox_id);
-	if(vox.id() == larcv::kINVALID_VOXELID)
-	  cluster.emplace(vox_id, at, true);
-	else if(at < vox.value())
-	  cluster.emplace(vox_id, at, false);
-      }
-    }
+		if (_use_lite) {
+			fill_sedep_v(
+				mcp_v,
+				part_idx_v,
+				meta,
+				event_de_v
+			);
+		} else {
+			fill_sedep_v(
+				mcp_v,
+				part_idx_v,
+				meta,
+				event_de_v,
+				event_dq_v,
+				event_dp_v,
+				event_dx_v,
+				event_dt_v,
+				event_at_v,
+				event_dedx_v
+			);
+		}
 
     if(_store_dedx) {
-      LARCV_INFO() << "Computing dE/dX for clusters: dx " << event_dx_v->as_vector().size() 
+      LARCV_INFO() << "Computing dE/dX for clusters: dx " << event_dx_v->as_vector().size()
 		   << " de " << event_de_v.as_vector().size() << std::endl;
       /*
       for(size_t cluster_idx=0; cluster_idx<cluster_de_v.size(); ++cluster_idx) {
@@ -216,13 +292,13 @@ namespace larcv {
 
     // report
     for(size_t part_idx=0; part_idx<mcp_v.size(); ++part_idx) {
-      LARCV_INFO() << "Track ID " << mcp_v[part_idx].track_id() 
+      LARCV_INFO() << "Track ID " << mcp_v[part_idx].track_id()
 		   << " PDG " << mcp_v[part_idx].pdg_code()
 		   << " Voxel Count " << event_de_v.as_vector().at(part_idx).size() << std::endl;
     }
 
     // assert
-    if( event_de_v.as_vector().size()  != (mcp_v.size() + 1) ) 
+    if( event_de_v.as_vector().size()  != (mcp_v.size() + 1) )
       { LARCV_ERROR() << "event_de_v size mismatch with mcp_v: " << event_de_v.as_vector().size()  << " vs. " << mcp_v.size(); throw std::exception(); }
     if( event_dx_v   && event_dx_v->as_vector().size() != (mcp_v.size() + 1) )
       { LARCV_ERROR() << "event_dx_v size mismatch with mcp_v: " << event_dx_v->as_vector().size() << " vs. " << mcp_v.size(); throw std::exception(); }
@@ -252,10 +328,10 @@ namespace larcv {
     if(_store_dt)   mgr.get_data<larcv::EventClusterVoxel3D>(_output_label + "_dt"  ).set(vsa_dt,meta);
     if(_store_at)   mgr.get_data<larcv::EventClusterVoxel3D>(_output_label + "_at"  ).set(vsa_at,meta);
     if(_store_dedx) mgr.get_data<larcv::EventClusterVoxel3D>(_output_label + "_dedx").set(vsa_dedx,meta);
-    */    
+    */
     return true;
   }
-      
+
   void SuperaSimEnergyDeposit::finalize()
   {}
 

--- a/SuperaSimEnergyDeposit.h
+++ b/SuperaSimEnergyDeposit.h
@@ -17,6 +17,8 @@
 //#ifndef __CLING__
 #include "SuperaBase.h"
 #include "larcv/core/DataFormat/BBox.h"
+#include "larcv/core/DataFormat/EventParticle.h"
+#include "larcv/core/DataFormat/EventVoxel3D.h"
 namespace larcv {
 
   /**
@@ -38,13 +40,33 @@ namespace larcv {
 
     void initialize();
 
+		void fill_sedep_v(
+				const std::vector<larcv::Particle> mcp_v,
+				std::vector<int>& part_idx_v,
+				larcv::Voxel3DMeta meta,
+				larcv::EventClusterVoxel3D& event_de_v
+				);
+
+		void fill_sedep_v(
+				const std::vector<larcv::Particle> mcp_v,
+				std::vector<int>& part_idx_v,
+				larcv::Voxel3DMeta meta,
+				larcv::EventClusterVoxel3D& event_de_v,
+				larcv::EventClusterVoxel3D* event_dq_v,
+				larcv::EventClusterVoxel3D* event_dp_v,
+				larcv::EventClusterVoxel3D* event_dx_v,
+				larcv::EventClusterVoxel3D* event_dt_v,
+				larcv::EventClusterVoxel3D* event_at_v,
+				larcv::EventClusterVoxel3D* event_dedx_v
+				);
+
     bool process(IOManager& mgr);
 
     void finalize();
 
   private:
 
-    bool _store_dx, _store_dq, _store_dp, _store_dt, _store_at, _store_dedx;
+    bool _store_dx, _store_dq, _store_dp, _store_dt, _store_at, _store_dedx, _use_lite;
     std::string _output_label, _particle_label;
     BBox3D _world_bounds;
 

--- a/SuperaSpacePoint.cxx
+++ b/SuperaSpacePoint.cxx
@@ -342,7 +342,7 @@ namespace larcv {
     };
 
     store_v2(v_charge,      "");
-    store_v2(v_charge_asym, "charge_asym");
+    //store_v2(v_charge_asym, "charge_asym");
     store_v2(v_chi2,        "chi2");
     store_v2(v_occupancy,   "occupancy");
     store_v2(v_nhits,       "nhits");

--- a/SuperaTrue2RecoVoxel3D.cxx
+++ b/SuperaTrue2RecoVoxel3D.cxx
@@ -173,6 +173,7 @@ namespace larcv {
 		if (_sps_producer_v.size() == 0)
 			LARCV_ERROR() << "No space point producers" << std::endl;
 
+    _useOrigTrackID = cfg.get<bool>("UseOrigTrackID",false);
     _use_true_pos = cfg.get<bool>("UseTruePosition",true);
     _twofold_matching = cfg.get<bool>("TwofoldMatching", false);
     _ref_meta3d_cluster3d = cfg.get<std::string>("Meta3DFromCluster3D","pcluster");
@@ -291,7 +292,7 @@ namespace larcv {
       	  if(vox_id == larcv::kINVALID_VOXELID) continue;
           true_voxel_ids.insert(vox_id);
 
-          hit.track_voxel_ids.emplace_back(vox_id, edep.trackID);
+          hit.track_voxel_ids.emplace_back(vox_id, _useOrigTrackID ? edep.origTrackID : edep.trackID);
           hit.n_electrons.push_back(edep.numElectrons);
         }
 

--- a/SuperaTrue2RecoVoxel3D.cxx
+++ b/SuperaTrue2RecoVoxel3D.cxx
@@ -288,7 +288,6 @@ namespace larcv {
           if(_use_true_pos) x_pos = edep.x;
 
           auto vox_id = meta3d.id(x_pos, edep.y, edep.z);
-					if ((x_pos > 0) && (x_pos < 10)) std::cout << x_pos << " " << edep.y << " " << edep.z << " " << vox_id << std::endl;
       	  if(vox_id == larcv::kINVALID_VOXELID) continue;
           true_voxel_ids.insert(vox_id);
 

--- a/SuperaTrue2RecoVoxel3D.h
+++ b/SuperaTrue2RecoVoxel3D.h
@@ -64,6 +64,7 @@ namespace larcv {
     bool _debug, _use_true_pos;
     bool _twofold_matching;
     bool _dump_to_csv;
+    bool _useOrigTrackID; ///< Whether to use origTrackID or trackID from SimChannel
 
     bool _post_averaging;
     double _post_averaging_threshold;

--- a/SuperaTypes.cxx
+++ b/SuperaTypes.cxx
@@ -13,5 +13,6 @@ namespace supera {
   template<> LArDataType_t LArDataType<supera::LArSimCh_t>()      { return LArDataType_t::kLArSimCh_t;     }
   template<> LArDataType_t LArDataType<supera::LArSimEnergyDeposit_t>()    { return LArDataType_t::kLArSimEnergyDeposit_t; }
   template<> LArDataType_t LArDataType<supera::LArSpacePoint_t>()    { return LArDataType_t::kLArSpacePoint_t; }
+  template<> LArDataType_t LArDataType<supera::LArOpFlash_t>()    { return LArDataType_t::kLArOpFlash_t; }
 }
 #endif

--- a/SuperaTypes.cxx
+++ b/SuperaTypes.cxx
@@ -7,6 +7,7 @@ namespace supera {
   template<> LArDataType_t LArDataType<supera::LArWire_t>()       { return LArDataType_t::kLArWire_t;      }
   template<> LArDataType_t LArDataType<supera::LArOpDigit_t>()    { return LArDataType_t::kLArOpDigit_t;   }
   template<> LArDataType_t LArDataType<supera::LArMCParticle_t>() { return LArDataType_t::kLArMCParticle_t;}
+  template<> LArDataType_t LArDataType<supera::LArMCMiniPart_t>() { return LArDataType_t::kLArMCMiniPart_t;}
   template<> LArDataType_t LArDataType<supera::LArMCTruth_t>()    { return LArDataType_t::kLArMCTruth_t;   }
   template<> LArDataType_t LArDataType<supera::LArMCTrack_t>()    { return LArDataType_t::kLArMCTrack_t;   }
   template<> LArDataType_t LArDataType<supera::LArMCShower_t>()   { return LArDataType_t::kLArMCShower_t;  }

--- a/SuperaTypes.cxx
+++ b/SuperaTypes.cxx
@@ -11,8 +11,9 @@ namespace supera {
   template<> LArDataType_t LArDataType<supera::LArMCTrack_t>()    { return LArDataType_t::kLArMCTrack_t;   }
   template<> LArDataType_t LArDataType<supera::LArMCShower_t>()   { return LArDataType_t::kLArMCShower_t;  }
   template<> LArDataType_t LArDataType<supera::LArSimCh_t>()      { return LArDataType_t::kLArSimCh_t;     }
-  template<> LArDataType_t LArDataType<supera::LArSimEnergyDeposit_t>()    { return LArDataType_t::kLArSimEnergyDeposit_t; }
-  template<> LArDataType_t LArDataType<supera::LArSpacePoint_t>()    { return LArDataType_t::kLArSpacePoint_t; }
-  template<> LArDataType_t LArDataType<supera::LArOpFlash_t>()    { return LArDataType_t::kLArOpFlash_t; }
+  template<> LArDataType_t LArDataType<supera::LArSimEnergyDeposit_t>()        { return LArDataType_t::kLArSimEnergyDeposit_t; }
+  template<> LArDataType_t LArDataType<supera::LArSimEnergyDepositLite_t>()    { return LArDataType_t::kLArSimEnergyDepositLite_t; }
+  template<> LArDataType_t LArDataType<supera::LArSpacePoint_t>()              { return LArDataType_t::kLArSpacePoint_t; }
+  template<> LArDataType_t LArDataType<supera::LArOpFlash_t>()                 { return LArDataType_t::kLArOpFlash_t; }
 }
 #endif

--- a/SuperaTypes.cxx
+++ b/SuperaTypes.cxx
@@ -15,5 +15,6 @@ namespace supera {
   template<> LArDataType_t LArDataType<supera::LArSimEnergyDepositLite_t>()    { return LArDataType_t::kLArSimEnergyDepositLite_t; }
   template<> LArDataType_t LArDataType<supera::LArSpacePoint_t>()              { return LArDataType_t::kLArSpacePoint_t; }
   template<> LArDataType_t LArDataType<supera::LArOpFlash_t>()                 { return LArDataType_t::kLArOpFlash_t; }
+  template<> LArDataType_t LArDataType<supera::LArCRTHit_t>()                  { return LArDataType_t::kLArCRTHit_t; }
 }
 #endif

--- a/SuperaTypes.h
+++ b/SuperaTypes.h
@@ -12,6 +12,7 @@ namespace supera {
     kLArOpDigit_t,   ///< raw::OpDetWaveform
     kLArMCTruth_t,   ///< simb::MCTruth
     kLArMCParticle_t,///< simb::MCParticle
+    kLArMCMiniPart_t,///< sim::MCParticleLite
     kLArMCTrack_t,   ///< sim::MCTrack
     kLArMCShower_t,  ///< sim::MCShower
     kLArSimCh_t,     ///< sim::SimChannel
@@ -31,6 +32,7 @@ namespace supera {
   template<> LArDataType_t LArDataType<supera::LArOpDigit_t>();
   template<> LArDataType_t LArDataType<supera::LArMCTruth_t>();
   template<> LArDataType_t LArDataType<supera::LArMCParticle_t>();
+  template<> LArDataType_t LArDataType<supera::LArMCMiniPart_t>();
   template<> LArDataType_t LArDataType<supera::LArMCTrack_t>();
   template<> LArDataType_t LArDataType<supera::LArMCShower_t>();
   template<> LArDataType_t LArDataType<supera::LArSimCh_t>();

--- a/SuperaTypes.h
+++ b/SuperaTypes.h
@@ -18,7 +18,8 @@ namespace supera {
     kLArSimEnergyDeposit_t, ///< sim::SimEnergyDeposit
     kLArSimEnergyDepositLite_t, ///< sim::SimEnergyDepositLite
     kLArSpacePoint_t, ///< simb::SpacePoint
-		kLArOpFlash_t,   ///< recob::OpFlash
+    kLArOpFlash_t,   ///< recob::OpFlash
+    kLArCRTHit_t,    ///< sbn::crt::CRTHit
     kLArDataTypeMax
   };
 
@@ -37,6 +38,7 @@ namespace supera {
   template<> LArDataType_t LArDataType<supera::LArSimEnergyDepositLite_t>();
   template<> LArDataType_t LArDataType<supera::LArSpacePoint_t>();
   template<> LArDataType_t LArDataType<supera::LArOpFlash_t>();
+  template<> LArDataType_t LArDataType<supera::LArCRTHit_t>();
 
   class RSEID {
   public:

--- a/SuperaTypes.h
+++ b/SuperaTypes.h
@@ -5,9 +5,9 @@
 #include "FMWKInterface.h"
 namespace supera {
 
-  /// enum to define LAr* data type 
+  /// enum to define LAr* data type
   enum class LArDataType_t : unsigned int{
-    kLArWire_t,      ///< recob::Wire 
+    kLArWire_t,      ///< recob::Wire
     kLArHit_t,       ///< recob::Hit
     kLArOpDigit_t,   ///< raw::OpDetWaveform
     kLArMCTruth_t,   ///< simb::MCTruth
@@ -17,7 +17,8 @@ namespace supera {
     kLArSimCh_t,     ///< sim::SimChannel
     kLArSimEnergyDeposit_t, ///< sim::SimEnergyDeposit
     kLArSpacePoint_t, ///< simb::SpacePoint
-    kLArDataTypeMax 
+		kLArOpFlash_t,   ///< recob::OpFlash
+    kLArDataTypeMax
   };
 
   template <class T>
@@ -33,6 +34,7 @@ namespace supera {
   template<> LArDataType_t LArDataType<supera::LArSimCh_t>();
   template<> LArDataType_t LArDataType<supera::LArSimEnergyDeposit_t>();
   template<> LArDataType_t LArDataType<supera::LArSpacePoint_t>();
+  template<> LArDataType_t LArDataType<supera::LArOpFlash_t>();
 
   class RSEID {
   public:
@@ -64,7 +66,7 @@ namespace supera {
 
     size_t run, subrun, event;
   };
-  
+
 }
 //#endif
 //#endif

--- a/SuperaTypes.h
+++ b/SuperaTypes.h
@@ -16,6 +16,7 @@ namespace supera {
     kLArMCShower_t,  ///< sim::MCShower
     kLArSimCh_t,     ///< sim::SimChannel
     kLArSimEnergyDeposit_t, ///< sim::SimEnergyDeposit
+    kLArSimEnergyDepositLite_t, ///< sim::SimEnergyDepositLite
     kLArSpacePoint_t, ///< simb::SpacePoint
 		kLArOpFlash_t,   ///< recob::OpFlash
     kLArDataTypeMax
@@ -33,6 +34,7 @@ namespace supera {
   template<> LArDataType_t LArDataType<supera::LArMCShower_t>();
   template<> LArDataType_t LArDataType<supera::LArSimCh_t>();
   template<> LArDataType_t LArDataType<supera::LArSimEnergyDeposit_t>();
+  template<> LArDataType_t LArDataType<supera::LArSimEnergyDepositLite_t>();
   template<> LArDataType_t LArDataType<supera::LArSpacePoint_t>();
   template<> LArDataType_t LArDataType<supera::LArOpFlash_t>();
 

--- a/experiments/icarus/ExperimentTypes.h
+++ b/experiments/icarus/ExperimentTypes.h
@@ -1,0 +1,9 @@
+#ifndef __SUPERA_EXPERIMENT_TYPES_CXX__
+#define __SUPERA_EXPERIMENT_TYPES_CXX__
+#include "sbnobj/Common/CRT/CRTHit.hh"
+
+namespace supera {
+	typedef sbn::crt::CRTHit   LArCRTHit_t;
+}
+
+#endif

--- a/experiments/icarus/FMWKInterface.cxx
+++ b/experiments/icarus/FMWKInterface.cxx
@@ -10,22 +10,6 @@
 #include "larevt/SpaceChargeServices/SpaceChargeService.h"
 #include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h" // RanItay Add
 
-//#include "LArUtil/SpaceChargeMicroBooNE.h"
-//
-//#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h" // RanItay Add
-//
-//#include "lardataobj/Simulation/SimEnergyDeposit.h"// RanItay Add
-//#include "larevt/SpaceChargeServices/SpaceChargeService.h" // RanItay Add
-//#include "ubevt/SpaceCharge/SpaceChargeMicroBooNE.h" // RanItay Add
-//
-
-
-
-//#include "lardataobj/Simulation/SimEnergyDeposit.h"// RanItay Add
-//#include "larevt/SpaceChargeServices/SpaceChargeService.h" // RanItay Add
-//#include "ubevt/SpaceCharge/SpaceChargeMicroBooNE.h" // RanItay Add
-
-
 namespace supera {
 
   ::geo::WireID ChannelToWireID(unsigned int ch)

--- a/experiments/uboone/ExperimentTypes.h
+++ b/experiments/uboone/ExperimentTypes.h
@@ -1,0 +1,4 @@
+#ifndef __SUPERA_EXPERIMENT_TYPES_CXX__
+#define __SUPERA_EXPERIMENT_TYPES_CXX__
+
+#endif

--- a/job/supera_mpvmpr.fcl
+++ b/job/supera_mpvmpr.fcl
@@ -3,8 +3,8 @@ ProcessDriver: {
   Verbosity:    2
   EnableFilter: true
   RandomAccess: false
-  ProcessType:  ["SuperaMCTruth","SuperaMCTruth","SuperaBBoxInteraction","SuperaMCParticleCluster","SuperaSimEnergyDeposit","SuperaSpacePoint","Tensor3DFromCluster3D","ThresholdTensor3D","CombineTensor3D","ParticleCorrector","EmptyTensorFilter","RescaleChargeTensor3D"]
-  ProcessName:  ["MultiPartVrtx","MultiPartRain","SuperaBBoxInteraction","SuperaMCParticleCluster","SuperaSimEnergyDeposit","SuperaSpacePoint","Tensor3DFromCluster3D","ThresholdTensor3D","CombineTensor3D","ParticleCorrector","EmptyTensorFilter","RescaleChargeTensor3D"]
+  ProcessType:  ["SuperaMCTruth","SuperaMCTruth","SuperaBBoxInteraction","SuperaMCParticleCluster","SuperaSimEnergyDeposit","SuperaSpacePoint","Tensor3DFromCluster3D","ThresholdTensor3D","CombineTensor3D","ParticleCorrector","EmptyTensorFilter","RescaleChargeTensor3D","SuperaOptical"]
+  ProcessName:  ["MultiPartVrtx","MultiPartRain","SuperaBBoxInteraction","SuperaMCParticleCluster","SuperaSimEnergyDeposit","SuperaSpacePoint","Tensor3DFromCluster3D","ThresholdTensor3D","CombineTensor3D","ParticleCorrector","EmptyTensorFilter","RescaleChargeTensor3D","SuperaOptical"]
 
   IOManager: {
     Verbosity:   2
@@ -18,6 +18,10 @@ ProcessDriver: {
   }
 
   ProcessList: {
+		SuperaOptical: {
+		  OpFlashProducers: ["opflashCryoE"]
+			OpFlashOutputs: ["cryoE"]
+		}
     EmptyTensorFilter: {
       Profile: true
       Tensor3DProducerList: ["reco"]

--- a/job/supera_mpvmpr.fcl
+++ b/job/supera_mpvmpr.fcl
@@ -57,14 +57,14 @@ ProcessDriver: {
       #MaskedTrue2RecoCluster3D: "masked_true2reco"
       DeltaSize: 10
       #EnergyDepositThreshold: 0.5
-      LArSimEnergyDepositProducer: "largeant TPCActive"
-      LArSimChProducer: ""
-      #LArSimEnergyDepositProducer: ""
-      #LArSimChProducer: "largeant"
+      #LArSimEnergyDepositProducer: "largeant TPCActive"
+      LArSimEnergyDepositLiteProducer: "sedlite"
+      #LArSimChProducer: ""
       Meta3DFromCluster3D: "mcst"
       Meta2DFromTensor2D:  ""
       Verbosity: 1
-      UseSimEnergyDeposit: true
+      UseSimEnergyDeposit: false
+      UseSimEnergyDepositLite: true
       UseSimEnergyDepositPoints: true
       CryostatList: [0,0,0,0,1,1,1,1]
       TPCList: [0,1,2,3,0,1,2,3]
@@ -113,7 +113,9 @@ ProcessDriver: {
       Verbosity: 2
       Profile: true
       LArMCTruthProducer: "generator"
-      LArSimEnergyDepositProducer: "largeant TPCActive"
+      #LArSimEnergyDepositProducer: "largeant TPCActive"
+      LArSimEnergyDepositLiteProducer: "sedlite"
+			UseSEDLite: true
       Origin: 0
       Cluster3DLabels: ["mcst","pcluster","sed","masked_true2reco"]
       Tensor3DLabels:  ["reco","pcluster_index","masked_true"]
@@ -133,8 +135,10 @@ ProcessDriver: {
     SuperaSimEnergyDeposit: {
       Verbosity: 1
       Profile: true
-      LArSimEnergyDepositProducer: "largeant TPCActive"
+      #LArSimEnergyDepositProducer: "largeant TPCActive"
+      LArSimEnergyDepositLiteProducer: "sedlite"
       LArMCShowerProducer: "mcreco"
+			UseSEDLite: true
       ParticleProducer: "pcluster"
       OutCluster3DLabel: "sed"
       StoreLength: false

--- a/setup.sh
+++ b/setup.sh
@@ -21,6 +21,7 @@ else
 	export SUPERADIR=$SUPERA_DIR;
 	ln -sf $SUPERA_DIR/experiments/$experiment/FMWKInterface.* $SUPERA_DIR;
 	ln -sf $SUPERA_DIR/experiments/$experiment/CMakeLists.txt $SUPERA_DIR;
+	ln -sf $SUPERA_DIR/experiments/$experiment/ExperimentTypes.h $SUPERA_DIR;
 	echo "set up for $experiment"
     fi
 fi


### PR DESCRIPTION
* New module `SuperaOptical` and new type `kLArOpFlash_t`
* New module `SuperaCRT` and new type `kLArCRTHit_t`
* Introduce experiment-dependent header file `ExperimentTypes.h` to contain experiment-specific includes (in this case, CRTHit header file which lives in SBN-specific repository)
* Introduce option to use SEDLite instead of SED in Supera

**This cannot be merged until the [relevant PR](https://github.com/LArSoft/lardataobj/pull/30) in LArSoft is merged (to make SEDLite header available).**