### PR TITLE
Feature/jdyer

### DIFF
--- a/experiments/icarus/CMakeLists.txt
+++ b/experiments/icarus/CMakeLists.txt
@@ -22,6 +22,7 @@ art_make_library(
     LIBRARY_NAME
         icarus_LArCVImageMaker
             LIBRARIES
+		sbnobj::Common_CRT
 		nurandom::RandomUtils_NuRandomService_service
 		larcore::Geometry_Geometry_service
 		lardataalg::DetectorInfo


### PR DESCRIPTION
explicitly include sbnobj library in CMakeLists.txt file so that sbncode can build "out of the box."