### PR TITLE
Feature/bearc trackid offsets

### DIFF
--- a/SuperaMCParticleCluster.cxx
+++ b/SuperaMCParticleCluster.cxx
@@ -170,6 +170,7 @@ namespace larcv {
     LARCV_DEBUG() << "****---- CreateParticleGroups" << std::endl;
     const larcv::Particle invalid_part;
     auto const& larmcp_v = LArData<supera::LArMCParticle_t>();
+    LARCV_DEBUG() << "larmcp_v size " << larmcp_v.size() << std::endl;
     auto const& parent_pdg_v = _mcpl.ParentPdgCode();
     auto const& trackid2index = _mcpl.TrackIdToIndex();
     std::vector<supera::ParticleGroup> result(trackid2index.size());
@@ -186,7 +187,7 @@ namespace larcv {
       if(pdg_code > 1000000) continue;
 
       supera::ParticleGroup grp(_valid_nplanes);
-      LARCV_DEBUG() << "grp.part make particle" << std::endl;
+      //LARCV_DEBUG() << "grp.part make particle" << std::endl;
       grp.part = this->MakeParticle(mcpart);
 
       if(mother_index >= 0)
@@ -611,11 +612,11 @@ namespace larcv {
             }
           }
 
-          LARCV_DEBUG() << "IDE ... TrackID " << edep.trackID << " E " << edep.energy << " Q " << edep.numElectrons << std::endl;
+          //LARCV_DEBUG() << "IDE ... TrackID " << edep.trackID << " E " << edep.energy << " Q " << edep.numElectrons << std::endl;
 
           if(skipped2d || skipped3d) {
 
-            LARCV_INFO() << "Skipped 2d/3d " << (skipped2d ? "1" : "0") << "/" << (skipped3d ? "1" : "0") << " TrackID " << edep.trackID
+            LARCV_DEBUG() << "Skipped 2d/3d " << (skipped2d ? "1" : "0") << "/" << (skipped3d ? "1" : "0") << " TrackID " << edep.trackID
              << " pos (" << pt.x << "," << pt.y << "," << pt.z << ")"
              << " ... TDC " << tick_ides.first << " => Tick " << time_pos
              << "... Wire " << wid.Wire
@@ -1259,7 +1260,7 @@ namespace larcv {
         grp.part.group_id(output_counter);
       }
       else{ // Fix this by setting UseOrigTrackID: false in superaMCParticleCluster fcl
-        LARCV_DEBUG() << "***--- Laura debug " << grp.part.track_id() << " " << grp.valid << " " << grp.size_all() << " " << grp.shape() << " " << larcv::kShapeLEScatter << trackid << std::endl;
+        //LARCV_DEBUG() << "***--- Laura debug " << grp.part.track_id() << " " << grp.valid << " " << grp.size_all() << " " << grp.shape() << " " << larcv::kShapeLEScatter << trackid << std::endl;
         
         if(!grp.valid) continue;
         if(grp.size_all()<1) continue;
@@ -1267,7 +1268,7 @@ namespace larcv {
       }
 
       //std::cout << grp.shape() << " " << grp.size_all() << std::endl;
-      LARCV_DEBUG() << "***--- track id in particle group : " << grp.part.track_id() << " "<< larcv::kINVALID_UINT << std::endl;
+      //LARCV_DEBUG() << "***--- track id in particle group : " << grp.part.track_id() << " "<< larcv::kINVALID_UINT << std::endl;
       if (grp.part.track_id() == larcv::kINVALID_UINT) continue;
       grp.part.id(output_counter);
       trackid2output[grp.part.track_id()] = output_counter;
@@ -2072,7 +2073,7 @@ namespace larcv {
              << semantic << " pixel count " << grp.vs.size()
              << " (not kShapeLEScatter) at line " << __LINE__
              << std::endl;
-        LARCV_DEBUG()<<grp.part.dump()<<std::endl;
+        //LARCV_DEBUG()<<grp.part.dump()<<std::endl;
         throw std::exception();
       }
       int trackid = grp.part.parent_track_id();

--- a/SuperaMCParticleCluster.h
+++ b/SuperaMCParticleCluster.h
@@ -111,6 +111,7 @@ namespace larcv {
     size_t _valid_nplanes;
     std::vector<larcv::ImageMeta> _meta2d_v;
     bool _useOrigTrackID; ///< Whether to use origTrackID or trackID from SimChannel/SimEnergyDeposit
+    std::vector<unsigned int> _trackid_offsets;
   };
 
   /**

--- a/job/run_supera_sbnd_corsika.fcl
+++ b/job/run_supera_sbnd_corsika.fcl
@@ -1,0 +1,83 @@
+#B. Carlson
+#bcarlson1@ufl.edu
+
+#include "cluster_sbnd.fcl"
+#include "services_sbnd.fcl"
+#include "simulationservices_sbnd.fcl"
+#include "simplemerge.fcl" 
+
+
+
+process_name: supera
+
+services:
+{
+  @table::sbnd_services
+  @table::sbnd_random_services
+  @table::sbnd_simulation_services # load simulation services in bulk
+}
+
+source:
+{
+  module_type: RootInput
+}
+
+physics:
+{
+
+ producers:
+ {
+   rns:      { module_type: "RandomNumberSaver" }
+   cluster3d: @local::standard_cluster3d
+   mcparticles: @local::simplemerge
+ }
+ analyzers:
+ { supera: {
+            module_type:     "LArSoftSuperaDriver"
+            supera_params:   "supera_sbnd_corsika_local.fcl"
+            out_filename:    "larcv.root"
+            unique_filename: false
+            stream:          "mc"
+            StrictDataLoading: false
+            }
+ }
+
+ simulate: [ rns, mcparticles, cluster3d] #merge the dropped particles with the normal particles and run cluster3d           
+ analyze:  [ supera ] # that's ok
+ stream:  [ out1 ]
+ trigger_paths: [ simulate ]
+ end_paths:     [analyze, stream] # get both larcv and larsoft output
+}
+
+outputs:
+{
+ out1:
+ {
+   module_type: RootOutput
+   fileName:    "larsoft.root"
+   dataTier:    "supera"
+   saveMemoryObjectThreshold: 0
+   compressionLevel: 1
+   fastCloning: false
+ }
+}
+
+services.TFileService.fileName: "ana.root"
+
+
+services.message.destinations :
+{
+  STDCOUT:
+  {
+     type:      "cout"      #tells the message service to output this destination to cout
+     threshold: "INFO"      #tells the message service that this destination applies to WARNING and higher level messages
+     categories:
+     {
+       default:
+       {
+         limit:       1000  #don't print anything at the infomsg level except the explicitly named categories
+         reportEvery: 1
+       }
+     }
+  }
+}

--- a/job/run_supera_sbnd_mpvmpr.fcl
+++ b/job/run_supera_sbnd_mpvmpr.fcl
@@ -1,0 +1,85 @@
+#B. Carlson
+#bcarlson1@ufl.edu
+
+#include "cluster_sbnd.fcl"
+#include "services_sbnd.fcl"
+#include "simulationservices_sbnd.fcl"
+#include "simplemerge.fcl" 
+
+process_name: supera
+
+services:
+{
+  @table::sbnd_services
+  @table::sbnd_random_services
+}
+
+source:
+{
+  module_type: RootInput
+}
+
+physics:
+{
+
+ producers:
+ {
+   rns:      { module_type: "RandomNumberSaver" }
+   cluster3d: @local::standard_cluster3d
+   mcparticles: @local::simplemerge
+ }
+ analyzers:
+ { supera: {
+            module_type:     "LArSoftSuperaDriver"
+            supera_params:   "supera_sbnd_mpvmpr_local.fcl"
+            out_filename:    "larcv.root"
+            unique_filename: false
+            stream:          "mc"
+            StrictDataLoading: false
+            }
+ }
+
+ simulate: [ rns, mcparticles, cluster3d] # you DO want to run cluster3d            
+ analyze:  [ supera ] # that's ok
+ stream:  [ out1 ]
+ trigger_paths: [ simulate ]
+ end_paths:     [analyze, stream] # get both larcv and larsoft output
+}
+
+outputs:
+{
+ out1:
+ {
+   module_type: RootOutput
+   fileName:    "larsoft.root"
+   dataTier:    "supera"
+   saveMemoryObjectThreshold: 0
+   compressionLevel: 1
+   fastCloning: false
+ }
+}
+
+services.TFileService.fileName: "ana.root"
+
+# 
+# MCParticle Merger
+#
+
+physics.producers.mcparticles.InputSourcesLabels: ["largeant","largeant:droppedMCParticles"]
+
+services.message.destinations :
+{
+  STDCOUT:
+  {
+     type:      "cout"      #tells the message service to output this destination to cout
+     threshold: "INFO"      #tells the message service that this destination applies to WARNING and higher level messages
+     categories:
+     {
+       default:
+       {
+         limit:       1000  #don't print anything at the infomsg level except the explicitly named categories
+         reportEvery: 1
+       }
+     }
+  }
+}

--- a/job/supera_sbnd_corsika.fcl
+++ b/job/supera_sbnd_corsika.fcl
@@ -60,7 +60,7 @@ ProcessDriver: {
       LArSimEnergyDepositLiteProducer: "sedlite"
       Meta3DFromCluster3D: "mcst"
       Meta2DFromTensor2D:  ""
-      Verbosity: 2
+      Verbosity: 0
       UseSimEnergyDeposit: false #AnalyzeSimEnergyDeposit if true, else AnalyzeFirstLastStep - default false
       UseSimEnergyDepositLite: true 
       UseSimEnergyDepositPoints: true
@@ -69,11 +69,12 @@ ProcessDriver: {
       TPCList: [0,1]
       PlaneList: []
       SemanticPriority: [1,2,0,3,4] # 0-4 for shower track michel delta LE-scattering
+      TrackIDOffsets: [10000000,20000000]
       SuperaTrue2RecoVoxel3D: {
         UseOrigTrackID: true
         DebugMode: true
         Profile: true
-        Verbosity: 2
+        Verbosity: 0
         Meta3DFromCluster3D: "pcluster"
         LArSimChProducer: "simdrift"
         LArSpacePointProducers: ["cluster3d"]

--- a/job/supera_sbnd_corsika.fcl
+++ b/job/supera_sbnd_corsika.fcl
@@ -1,0 +1,171 @@
+#B. Carlson
+#bcarlson1@ufl.edu
+
+ProcessDriver: {
+
+  Verbosity:    2
+  EnableFilter: true
+  RandomAccess: false
+  ProcessType:  ["SuperaMCTruth","SuperaMCTruth","SuperaBBoxInteraction","SuperaMCParticleCluster","SuperaSimEnergyDeposit","SuperaSpacePoint","Tensor3DFromCluster3D","CombineTensor3D","ThresholdTensor3D","CombineTensor3D","ParticleCorrector","EmptyTensorFilter","RescaleChargeTensor3D"]
+  ProcessName:  ["MultiPartVrtx","MultiPartRain","SuperaBBoxInteraction","SuperaMCParticleCluster","SuperaSimEnergyDeposit","SuperaSpacePoint","Tensor3DFromCluster3D","CombineTensor3DGhost","ThresholdTensor3D","CombineTensor3D","ParticleCorrector","EmptyTensorFilter","RescaleChargeTensor3D"]
+
+  IOManager: {
+    Verbosity:   2
+    Name:        "IOManager"
+    IOMode:      1
+    OutFileName: "out_test.root"
+    InputFiles:  []
+    InputDirs:   []
+    StoreOnlyType: []
+    StoreOnlyName: []
+  }
+
+  ProcessList: {
+    EmptyTensorFilter: {
+      Tensor3DProducerList: ["pcluster_semantics_ghost"]
+      MinVoxel3DCountList:  [1]
+    }
+
+    RescaleChargeTensor3D: {
+      HitKeyProducerList:    ["reco_hit_key0","reco_hit_key1","reco_hit_key2"]
+      HitChargeProducerList: ["reco_hit_charge0","reco_hit_charge1","reco_hit_charge2"]
+      OutputProducer:        "reco_rescaled"
+      ReferenceProducer:     "pcluster"
+    }
+
+    ThresholdTensor3D: { # fill with ghost value (5)
+      TargetProducer: "pcluster_semantics_ghost"
+      OutputProducer: "pcluster_semantics_ghost"
+      PaintValue: 5
+    }
+
+    CombineTensor3DGhost: { # Combine voxels
+      OutputProducer: "pcluster_semantics_ghost"
+      Tensor3DProducers: ["reco"]
+      PoolType: 0
+    }
+
+    CombineTensor3D: {
+      Tensor3DProducers: ["pcluster_semantics_ghost","pcluster_semantics"]
+      OutputProducer:    "pcluster_semantics_ghost"
+      PoolType: 0
+    }
+
+    SuperaMCParticleCluster: {
+      OutputLabel: "pcluster"
+      LArMCParticleProducer: "mcparticles" # produced when merging from previous stage
+      LArMCShowerProducer: "mcreco"
+      LArMCTrackProducer:  "mcreco"
+      DeltaSize: 10
+      LArSimEnergyDepositLiteProducer: "sedlite"
+      Meta3DFromCluster3D: "mcst"
+      Meta2DFromTensor2D:  ""
+      Verbosity: 2
+      UseSimEnergyDeposit: false #AnalyzeSimEnergyDeposit if true, else AnalyzeFirstLastStep - default false
+      UseSimEnergyDepositLite: true 
+      UseSimEnergyDepositPoints: true
+      UseOrigTrackID: true
+      CryostatList: [0,0]
+      TPCList: [0,1]
+      PlaneList: []
+      SemanticPriority: [1,2,0,3,4] # 0-4 for shower track michel delta LE-scattering
+      SuperaTrue2RecoVoxel3D: {
+        UseOrigTrackID: true
+        DebugMode: true
+        Profile: true
+        Verbosity: 2
+        Meta3DFromCluster3D: "pcluster"
+        LArSimChProducer: "simdrift"
+        LArSpacePointProducers: ["cluster3d"]
+        OutputTensor3D:  "masked_true"
+        OutputCluster3D: "masked_true2reco"
+        TwofoldMatching: true
+        UseTruePosition: true
+        HitThresholdNe: 175
+        HitWindowTicks: 5 #15
+        HitPeakFinding: false
+        PostAveraging: true
+        PostAveragingThreshold_cm: 0.425
+        DumpToCSV: true
+        RecoChargeRange: [-1000,50000]
+				VoxelDistanceThreshold: 1. #3
+      }
+    }
+
+    MultiPartVrtx: {
+      Verbosity: 2
+      LArMCTruthProducer: "generator"
+      OutParticleLabel: "mpv"
+      Origin: 0
+    }
+    MultiPartRain: {
+      Verbosity: 2
+      LArMCTruthProducer: "corsika"
+      OutParticleLabel: "mpr"
+      Origin: 0
+    }
+
+    SuperaBBoxInteraction: {
+      Verbosity: 2
+      LArMCTruthProducer: "generator"
+      #LArSimEnergyDepositProducer: "largeant TPCActive"
+      LArSimEnergyDepositLiteProducer: "sedlite"
+			UseSEDLite: true
+      Origin: 0
+      Cluster3DLabels: ["mcst","pcluster","sed","masked_true2reco"]
+      Tensor3DLabels:  ["reco","pcluster_index","masked_true"]
+      BBoxSize: [614.4, 614.4, 614.4] # 2048 pixels of 0.3 mm
+      BBoxBottom: [-307.2, -307.2, -57.4] # centered on the detector center with some padding
+      VoxelSize: [0.3,0.3,0.3]
+      UseFixedBBox: true
+      CryostatList: [0,0]
+      TPCList: [0,1]
+    }
+
+    SuperaSimEnergyDeposit: {
+      Verbosity: 2
+      #LArSimEnergyDepositProducer: "largeant TPCActive"
+      LArSimEnergyDepositLiteProducer: "sedlite"
+      LArMCShowerProducer: "mcreco"
+			UseSEDLite: true
+      ParticleProducer: "pcluster"
+      OutCluster3DLabel: "sed"
+      StoreLength: false
+      StoreCharge: false
+      StorePhoton: false
+      StoreDiffTime: false
+      StoreAbsTime: true
+      StoreDEDX: false
+      TPCList: [0,1]
+      CryostatList: [0,0]
+    }
+
+    ParticleCorrector: {
+      Verbosity: 2
+      Cluster3DProducer: "pcluster_highE"
+      ParticleProducer:  "pcluster"
+      OutputProducer:    "corrected"
+      VoxelMinValue:     -1000
+   }
+
+
+    Tensor3DFromCluster3D: {
+      Verbosity: 2
+      Cluster3DProducerList: ["pcluster","sed"]
+      OutputProducerList:    ["pcluster","sed"]
+      PITypeList:  [1,1]
+      FixedPIList: [0.,0.]
+    }
+
+    SuperaSpacePoint: {
+      Verbosity: 2
+      SpacePointProducers: ["cluster3d"]
+      OutputLabel:        "reco"
+      DropOutput: ["hit_amp","hit_rms","hit_mult"]
+      StoreWireInfo: true
+      RecoChargeRange: [-1000, 50000]
+    }
+
+  }
+}
+

--- a/job/supera_sbnd_mpvmpr.fcl
+++ b/job/supera_sbnd_mpvmpr.fcl
@@ -1,0 +1,172 @@
+#B. Carlson
+#bcarlson1@ufl.edu
+
+ProcessDriver: {
+
+  Verbosity:    2
+  EnableFilter: true
+  RandomAccess: false
+  ProcessType:  ["SuperaMCTruth","SuperaMCTruth","SuperaBBoxInteraction","SuperaMCParticleCluster","SuperaSimEnergyDeposit","SuperaSpacePoint","Tensor3DFromCluster3D","CombineTensor3D","ThresholdTensor3D","CombineTensor3D","ParticleCorrector","EmptyTensorFilter","RescaleChargeTensor3D"]
+  ProcessName:  ["MultiPartVrtx","MultiPartRain","SuperaBBoxInteraction","SuperaMCParticleCluster","SuperaSimEnergyDeposit","SuperaSpacePoint","Tensor3DFromCluster3D","CombineTensor3DGhost","ThresholdTensor3D","CombineTensor3D","ParticleCorrector","EmptyTensorFilter","RescaleChargeTensor3D"]
+
+  IOManager: {
+    Verbosity:   2
+    Name:        "IOManager"
+    IOMode:      1
+    OutFileName: "out_test.root"
+    InputFiles:  []
+    InputDirs:   []
+    StoreOnlyType: []
+    StoreOnlyName: []
+  }
+
+  ProcessList: {
+    EmptyTensorFilter: {
+      Tensor3DProducerList: ["pcluster_semantics_ghost"]
+      MinVoxel3DCountList:  [1]
+    }
+
+    RescaleChargeTensor3D: {
+      HitKeyProducerList:    ["reco_hit_key0","reco_hit_key1","reco_hit_key2"]
+      HitChargeProducerList: ["reco_hit_charge0","reco_hit_charge1","reco_hit_charge2"]
+      OutputProducer:        "reco_rescaled"
+      ReferenceProducer:     "pcluster"
+    }
+
+    ThresholdTensor3D: { # fill with ghost value (5)
+      TargetProducer: "pcluster_semantics_ghost"
+      OutputProducer: "pcluster_semantics_ghost"
+      PaintValue: 5
+    }
+
+    CombineTensor3DGhost: { # Combine voxels
+      OutputProducer: "pcluster_semantics_ghost"
+      Tensor3DProducers: ["reco"]
+      PoolType: 0
+    }
+
+    CombineTensor3D: {
+      Tensor3DProducers: ["pcluster_semantics_ghost","pcluster_semantics"]
+      OutputProducer:    "pcluster_semantics_ghost"
+      PoolType: 0
+    }
+
+    SuperaMCParticleCluster: {
+      OutputLabel: "pcluster"
+      LArMCParticleProducer: "mcparticles"
+      LArMCShowerProducer: "mcreco"
+      LArMCTrackProducer:  "mcreco"
+      DeltaSize: 10
+      #LArSimEnergyDepositProducer: "ionandscintout"
+      LArSimEnergyDepositLiteProducer: "sedlite"
+      Meta3DFromCluster3D: "mcst"
+      Meta2DFromTensor2D:  ""
+      Verbosity: 2
+      UseSimEnergyDeposit: false
+      UseSimEnergyDepositLite: true
+      UseSimEnergyDepositPoints: true
+      UseOrigTrackID: true
+      CryostatList: [0,0]
+      TPCList: [0,1]
+      PlaneList: []
+      SemanticPriority: [1,2,0,3,4] # 0-4 for shower track michel delta LE-scattering
+      SuperaTrue2RecoVoxel3D: {
+        UseOrigTrackID: true
+        DebugMode: true
+        Profile: true
+        Verbosity: 2
+        Meta3DFromCluster3D: "pcluster"
+        LArSimChProducer: "simdrift"
+        LArSpacePointProducers: ["cluster3d"]
+        OutputTensor3D:  "masked_true"
+        OutputCluster3D: "masked_true2reco"
+        TwofoldMatching: true
+        UseTruePosition: true
+        HitThresholdNe: 175
+        HitWindowTicks: 5 #15
+        HitPeakFinding: false
+        PostAveraging: true
+        PostAveragingThreshold_cm: 0.425
+        DumpToCSV: false
+        RecoChargeRange: [-1000,50000]
+				VoxelDistanceThreshold: 1. #3
+      }
+    }
+
+    MultiPartVrtx: {
+      Verbosity: 2
+      LArMCTruthProducer: "generator"
+      OutParticleLabel: "mpv"
+      Origin: 0
+    }
+    MultiPartRain: {
+      Verbosity: 2
+      LArMCTruthProducer: "corsika"
+      OutParticleLabel: "mpr"
+      Origin: 0
+    }
+
+    SuperaBBoxInteraction: {
+      Verbosity: 2
+      LArMCTruthProducer: "generator"
+      #LArSimEnergyDepositProducer: "largeant TPCActive"
+      LArSimEnergyDepositLiteProducer: "sedlite"
+			UseSEDLite: true
+      Origin: 0
+      Cluster3DLabels: ["mcst","pcluster","sed","masked_true2reco"]
+      Tensor3DLabels:  ["reco","pcluster_index","masked_true"]
+      BBoxSize: [614.4, 614.4, 614.4] # 2048 pixels of 0.3 mm
+      BBoxBottom: [-307.2, -307.2, -57.4] # centered on the detector center with some padding
+      VoxelSize: [0.3,0.3,0.3]
+      UseFixedBBox: true
+      CryostatList: [0,0]
+      TPCList: [0,1]
+    }
+
+    SuperaSimEnergyDeposit: {
+      Verbosity: 2
+      #LArSimEnergyDepositProducer: "largeant TPCActive"
+      LArSimEnergyDepositLiteProducer: "sedlite"
+      LArMCShowerProducer: "mcreco"
+			UseSEDLite: true
+      ParticleProducer: "pcluster"
+      OutCluster3DLabel: "sed"
+      StoreLength: false
+      StoreCharge: false
+      StorePhoton: false
+      StoreDiffTime: false
+      StoreAbsTime: true
+      StoreDEDX: false
+      TPCList: [0,1]
+      CryostatList: [0,0]
+    }
+
+    ParticleCorrector: {
+      Verbosity: 2
+      Cluster3DProducer: "pcluster_highE"
+      ParticleProducer:  "pcluster"
+      OutputProducer:    "corrected"
+      VoxelMinValue:     -1000
+   }
+
+
+    Tensor3DFromCluster3D: {
+      Verbosity: 2
+      Cluster3DProducerList: ["pcluster","sed"]
+      OutputProducerList:    ["pcluster","sed"]
+      PITypeList:  [1,1]
+      FixedPIList: [0.,0.]
+    }
+
+    SuperaSpacePoint: {
+      Verbosity: 2
+      SpacePointProducers: ["cluster3d"]
+      OutputLabel:        "reco"
+      DropOutput: ["hit_amp","hit_rms","hit_mult"]
+      StoreWireInfo: true
+      RecoChargeRange: [-1000, 50000]
+    }
+
+  }
+}
+


### PR DESCRIPTION
SBND sets the track ID of ancestors to 0 if it's before the primary for corsika and bnb. This causes the information to be set to dumby values. If you set the TrackID Offsets to what this dumby value is, it'll set the information to the most recent parentage which is what supera expects.

Dependent on these being pushed first since i can't unstage those commits from my changes. I can do it by hand if need be
* https://github.com/DeepLearnPhysics/Supera/pull/26
* https://github.com/DeepLearnPhysics/Supera/pull/25