### PR TITLE
Temporarily disable throwing exceptions for bad IDs

### DIFF
--- a/SuperaMCParticleCluster.cxx
+++ b/SuperaMCParticleCluster.cxx
@@ -2362,7 +2362,7 @@ namespace larcv {
           LARCV_CRITICAL() << "Particle index " << part_index << " holds particle w/ an ID "
                            << part.id() << std::endl
                            << part.dump() << std::endl;
-          //throw std::exception(); Temporarily disable breaking the code
+          throw std::exception();
         }
         if (part.parent_id() != larcv::kINVALID_INSTANCEID && part.parent_id() >= part_v.size()) {
           LARCV_CRITICAL() << "Particle index " << part_index
@@ -2370,14 +2370,14 @@ namespace larcv {
                            << std::endl
                            << part.dump() << std::endl
                            << part_grp_v[part.parent_track_id()].part.dump() << std::endl;
-          //throw std::exception(); Temporarily disable breaking the code
+          throw std::exception();
         }
         if (part.group_id() == larcv::kINVALID_INSTANCEID || part.group_id() >= part_v.size()) {
           LARCV_CRITICAL() << "Particle index " << part_index
                            << " holds particle w/ an invalid group ID " << part.group_id()
                            << std::endl
                            << part.dump() << std::endl;
-          //throw std::exception(); Temporarily disable breaking the code
+          throw std::exception();
         }
         if (part.parent_id() == part.id() || part.parent_id() == larcv::kINVALID_INSTANCEID)
           continue;

--- a/SuperaMCParticleCluster.cxx
+++ b/SuperaMCParticleCluster.cxx
@@ -2362,7 +2362,7 @@ namespace larcv {
           LARCV_CRITICAL() << "Particle index " << part_index << " holds particle w/ an ID "
                            << part.id() << std::endl
                            << part.dump() << std::endl;
-          throw std::exception();
+          //throw std::exception(); Temporarily disable breaking the code
         }
         if (part.parent_id() != larcv::kINVALID_INSTANCEID && part.parent_id() >= part_v.size()) {
           LARCV_CRITICAL() << "Particle index " << part_index
@@ -2370,14 +2370,14 @@ namespace larcv {
                            << std::endl
                            << part.dump() << std::endl
                            << part_grp_v[part.parent_track_id()].part.dump() << std::endl;
-          throw std::exception();
+          //throw std::exception(); Temporarily disable breaking the code
         }
         if (part.group_id() == larcv::kINVALID_INSTANCEID || part.group_id() >= part_v.size()) {
           LARCV_CRITICAL() << "Particle index " << part_index
                            << " holds particle w/ an invalid group ID " << part.group_id()
                            << std::endl
                            << part.dump() << std::endl;
-          throw std::exception();
+          //throw std::exception(); Temporarily disable breaking the code
         }
         if (part.parent_id() == part.id() || part.parent_id() == larcv::kINVALID_INSTANCEID)
           continue;

--- a/job/supera_sbnd_corsika.fcl
+++ b/job/supera_sbnd_corsika.fcl
@@ -69,6 +69,7 @@ ProcessDriver: {
       TPCList: [0,1]
       PlaneList: []
       SemanticPriority: [1,2,0,3,4] # 0-4 for shower track michel delta LE-scattering
+      CheckParticleValidity: false
       SuperaTrue2RecoVoxel3D: {
         UseOrigTrackID: true
         DebugMode: true

--- a/job/supera_sbnd_mpvmpr.fcl
+++ b/job/supera_sbnd_mpvmpr.fcl
@@ -69,6 +69,7 @@ ProcessDriver: {
       TPCList: [0,1]
       PlaneList: []
       SemanticPriority: [1,2,0,3,4] # 0-4 for shower track michel delta LE-scattering
+      CheckParticleValidity: false
       SuperaTrue2RecoVoxel3D: {
         UseOrigTrackID: true
         DebugMode: true


### PR DESCRIPTION
These changes are needed to not break Supera when running during production.