### PR TITLE
SBND Drop 2D information

### DIFF
--- a/job/run_supera_sbnd_corsika.fcl
+++ b/job/run_supera_sbnd_corsika.fcl
@@ -11,6 +11,7 @@ process_name: supera
 
 services:
 {
+  TFileService: { fileName: "larcv.root" }
   @table::sbnd_services
   @table::sbnd_random_services
   @table::sbnd_simulation_services # load simulation services in bulk
@@ -33,7 +34,7 @@ physics:
  { supera: {
             module_type:     "LArSoftSuperaDriver"
             supera_params:   "supera_sbnd_corsika.fcl"
-            out_filename:    "%larcv_ifb_%p-%tc.root"
+            out_filename:    "larcv.root"
             unique_filename: false
             stream:          "mc"
             StrictDataLoading: false

--- a/job/run_supera_sbnd_corsika.fcl
+++ b/job/run_supera_sbnd_corsika.fcl
@@ -11,7 +11,6 @@ process_name: supera
 
 services:
 {
-  TFileService: { fileName: "larcv.root" }
   @table::sbnd_services
   @table::sbnd_random_services
   @table::sbnd_simulation_services # load simulation services in bulk
@@ -34,7 +33,7 @@ physics:
  { supera: {
             module_type:     "LArSoftSuperaDriver"
             supera_params:   "supera_sbnd_corsika.fcl"
-            out_filename:    "larcv.root"
+            out_filename:    "%larcv_ifb_%p-%tc.root"
             unique_filename: false
             stream:          "mc"
             StrictDataLoading: false

--- a/job/supera_sbnd_corsika.fcl
+++ b/job/supera_sbnd_corsika.fcl
@@ -162,7 +162,7 @@ ProcessDriver: {
       Verbosity: 2
       SpacePointProducers: ["cluster3d"]
       OutputLabel:        "reco"
-      DropOutput: ["hit_amp","hit_rms","hit_mult"]
+      DropOutput: ["hit_amp","hit_rms","hit_mult","hit_charge","hit_time","hit_key"]
       StoreWireInfo: true
       RecoChargeRange: [-1000, 50000]
     }

--- a/job/supera_sbnd_corsika.fcl
+++ b/job/supera_sbnd_corsika.fcl
@@ -162,7 +162,7 @@ ProcessDriver: {
       Verbosity: 2
       SpacePointProducers: ["cluster3d"]
       OutputLabel:        "reco"
-      DropOutput: ["hit_amp","hit_rms","hit_mult","hit_charge","hit_time","hit_key"]
+      DropOutput: ["hit_amp","hit_rms","hit_mult","hit_time"]
       StoreWireInfo: true
       RecoChargeRange: [-1000, 50000]
     }

--- a/job/supera_sbnd_data.fcl
+++ b/job/supera_sbnd_data.fcl
@@ -21,91 +21,6 @@ ProcessDriver: {
   }
 
   ProcessList: {
-    EmptyTensorFilter: {
-      Tensor3DProducerList: ["pcluster_semantics_ghost"]
-      MinVoxel3DCountList:  [1]
-    }
-
-    RescaleChargeTensor3D: {
-      HitKeyProducerList:    ["reco_hit_key0","reco_hit_key1","reco_hit_key2"]
-      HitChargeProducerList: ["reco_hit_charge0","reco_hit_charge1","reco_hit_charge2"]
-      OutputProducer:        "reco_rescaled"
-      ReferenceProducer:     "pcluster"
-    }
-
-    ThresholdTensor3D: { # fill with ghost value (5)
-      TargetProducer: "pcluster_semantics_ghost"
-      OutputProducer: "pcluster_semantics_ghost"
-      PaintValue: 5
-    }
-
-    CombineTensor3DGhost: { # Combine voxels
-      OutputProducer: "pcluster_semantics_ghost"
-      Tensor3DProducers: ["reco"]
-      PoolType: 0
-    }
-
-    CombineTensor3D: {
-      Tensor3DProducers: ["pcluster_semantics_ghost","pcluster_semantics"]
-      OutputProducer:    "pcluster_semantics_ghost"
-      PoolType: 0
-    }
-
-    SuperaMCParticleCluster: {
-      OutputLabel: "pcluster"
-      LArMCParticleProducer: "simplemerge" # produced when merging from previous stage
-      LArMCShowerProducer: "mcreco"
-      LArMCTrackProducer:  "mcreco"
-      DeltaSize: 10
-      LArSimEnergyDepositLiteProducer: "sedlite"
-      Meta3DFromCluster3D: "mcst"
-      Meta2DFromTensor2D:  ""
-      Verbosity: 2
-      UseSimEnergyDeposit: false #AnalyzeSimEnergyDeposit if true, else AnalyzeFirstLastStep - default false
-      UseSimEnergyDepositLite: false 
-      UseSimEnergyDepositPoints: false
-      UseOrigTrackID: true
-      CryostatList: [0,0]
-      TPCList: [0,1]
-      PlaneList: []
-      SemanticPriority: [1,2,0,3,4] # 0-4 for shower track michel delta LE-scattering
-      CheckParticleValidity: false #set false, but this needs to be checked later
-      SuperaTrue2RecoVoxel3D: {
-        UseOrigTrackID: true
-        DebugMode: true
-        Profile: true
-        Verbosity: 2
-        Meta3DFromCluster3D: "pcluster"
-        LArSimChProducer: "simtpc2d simpleSC"
-        LArSpacePointProducers: ["cluster3d"]
-        OutputTensor3D:  "masked_true"
-        OutputCluster3D: "masked_true2reco"
-        TwofoldMatching: true
-        UseTruePosition: true
-        HitThresholdNe: 175
-        HitWindowTicks: 5 #15
-        HitPeakFinding: false
-        PostAveraging: true
-        PostAveragingThreshold_cm: 0.425
-        DumpToCSV: false
-        RecoChargeRange: [-1000,50000]
-				VoxelDistanceThreshold: 1. #3
-      }
-    }
-
-    MultiPartVrtx: {
-      Verbosity: 2
-      LArMCTruthProducer: "generator"
-      OutParticleLabel: "mpv"
-      Origin: 0
-    }
-    MultiPartRain: {
-      Verbosity: 2
-      LArMCTruthProducer: "corsika"
-      OutParticleLabel: "mpr"
-      Origin: 0
-    }
-
     SuperaBBoxInteraction: {
       Verbosity: 2
       LArMCTruthProducer: "generator"
@@ -122,47 +37,12 @@ ProcessDriver: {
       CryostatList: [0,0]
       TPCList: [0,1]
     }
-
-    SuperaSimEnergyDeposit: {
-      Verbosity: 2
-      #LArSimEnergyDepositProducer: "largeant TPCActive"
-      LArSimEnergyDepositLiteProducer: "sedlite"
-      LArMCShowerProducer: "mcreco"
-			UseSEDLite: true
-      ParticleProducer: "pcluster"
-      OutCluster3DLabel: "sed"
-      StoreLength: false
-      StoreCharge: false
-      StorePhoton: false
-      StoreDiffTime: false
-      StoreAbsTime: true
-      StoreDEDX: false
-      TPCList: [0,1]
-      CryostatList: [0,0]
-    }
-
-    ParticleCorrector: {
-      Verbosity: 2
-      Cluster3DProducer: "pcluster_highE"
-      ParticleProducer:  "pcluster"
-      OutputProducer:    "corrected"
-      VoxelMinValue:     -1000
-   }
-
-
-    Tensor3DFromCluster3D: {
-      Verbosity: 2
-      Cluster3DProducerList: ["pcluster","sed"]
-      OutputProducerList:    ["pcluster","sed"]
-      PITypeList:  [1,1]
-      FixedPIList: [0.,0.]
-    }
-
+    
     SuperaSpacePoint: {
       Verbosity: 2
       SpacePointProducers: ["cluster3d"]
       OutputLabel:        "reco"
-      DropOutput: ["hit_amp","hit_rms","hit_mult"]
+      DropOutput: ["hit_amp","hit_rms","hit_mult","hit_charge","hit_time","hit_key"]
       StoreWireInfo: true
       RecoChargeRange: [-1000, 50000]
     }

--- a/job/supera_sbnd_data.fcl
+++ b/job/supera_sbnd_data.fcl
@@ -42,7 +42,7 @@ ProcessDriver: {
       Verbosity: 2
       SpacePointProducers: ["cluster3d"]
       OutputLabel:        "reco"
-      DropOutput: ["hit_amp","hit_rms","hit_mult","hit_charge","hit_time","hit_key"]
+      DropOutput: ["hit_amp","hit_rms","hit_mult","hit_time"]
       StoreWireInfo: true
       RecoChargeRange: [-1000, 50000]
     }

--- a/job/supera_sbnd_mpvmpr.fcl
+++ b/job/supera_sbnd_mpvmpr.fcl
@@ -163,7 +163,7 @@ ProcessDriver: {
       Verbosity: 2
       SpacePointProducers: ["cluster3d"]
       OutputLabel:        "reco"
-      DropOutput: ["hit_amp","hit_rms","hit_mult"]
+      DropOutput: ["hit_amp","hit_rms","hit_mult","hit_charge","hit_time","hit_key"]
       StoreWireInfo: true
       RecoChargeRange: [-1000, 50000]
     }

--- a/job/supera_sbnd_mpvmpr.fcl
+++ b/job/supera_sbnd_mpvmpr.fcl
@@ -163,7 +163,7 @@ ProcessDriver: {
       Verbosity: 2
       SpacePointProducers: ["cluster3d"]
       OutputLabel:        "reco"
-      DropOutput: ["hit_amp","hit_rms","hit_mult","hit_charge","hit_time","hit_key"]
+      DropOutput: ["hit_amp","hit_rms","hit_mult","hit_time"]
       StoreWireInfo: true
       RecoChargeRange: [-1000, 50000]
     }


### PR DESCRIPTION
## Description
Drop cluster3d 2d hit information from larcv file. Saves ~75% of the space (80 MB -> 20 MB) on test files.