### PR TITLE
SBND Supera space point ghost labels

### DIFF
--- a/job/supera_sbnd_corsika.fcl
+++ b/job/supera_sbnd_corsika.fcl
@@ -82,14 +82,14 @@ ProcessDriver: {
         OutputCluster3D: "masked_true2reco"
         TwofoldMatching: true
         UseTruePosition: true
-        HitThresholdNe: 175
-        HitWindowTicks: 5 #15
+        HitThresholdNe: 100
+        HitWindowTicks: 10
         HitPeakFinding: false
         PostAveraging: true
-        PostAveragingThreshold_cm: 0.425
+        PostAveragingThreshold_cm: 0.7
         DumpToCSV: false
         RecoChargeRange: [-1000,50000]
-				VoxelDistanceThreshold: 1. #3
+				VoxelDistanceThreshold: 2.
       }
     }
 

--- a/job/supera_sbnd_data.fcl
+++ b/job/supera_sbnd_data.fcl
@@ -6,8 +6,8 @@ ProcessDriver: {
   Verbosity:    2
   EnableFilter: true
   RandomAccess: false
-  ProcessType:  ["SuperaBBoxInteraction","SuperaSpacePoint"]#,"SuperaOptical"]
-  ProcessName:  ["SuperaBBoxInteraction","SuperaSpacePoint"]#,"SuperaOptical"]
+  ProcessType:  ["SuperaBBoxInteraction","SuperaSpacePoint","SuperaOptical"]
+  ProcessName:  ["SuperaBBoxInteraction","SuperaSpacePoint","SuperaOptical"]
 
   IOManager: {
     Verbosity:   2

--- a/job/supera_sbnd_data.fcl
+++ b/job/supera_sbnd_data.fcl
@@ -82,14 +82,14 @@ ProcessDriver: {
         OutputCluster3D: "masked_true2reco"
         TwofoldMatching: true
         UseTruePosition: true
-        HitThresholdNe: 175
-        HitWindowTicks: 5 #15
+        HitThresholdNe: 100
+        HitWindowTicks: 10
         HitPeakFinding: false
         PostAveraging: true
-        PostAveragingThreshold_cm: 0.425
+        PostAveragingThreshold_cm: 0.7
         DumpToCSV: false
         RecoChargeRange: [-1000,50000]
-				VoxelDistanceThreshold: 1. #3
+				VoxelDistanceThreshold: 2.
       }
     }
 

--- a/job/supera_sbnd_data_noflash.fcl
+++ b/job/supera_sbnd_data_noflash.fcl
@@ -1,0 +1,55 @@
+#B. Carlson
+#bcarlson1@ufl.edu
+
+ProcessDriver: {
+
+  Verbosity:    2
+  EnableFilter: true
+  RandomAccess: false
+  ProcessType:  ["SuperaBBoxInteraction","SuperaSpacePoint"]#,"SuperaOptical"]
+  ProcessName:  ["SuperaBBoxInteraction","SuperaSpacePoint"]#,"SuperaOptical"]
+
+  IOManager: {
+    Verbosity:   2
+    Name:        "IOManager"
+    IOMode:      1
+    OutFileName: "out_test.root"
+    InputFiles:  []
+    InputDirs:   []
+    StoreOnlyType: []
+    StoreOnlyName: []
+  }
+
+  ProcessList: {
+    SuperaBBoxInteraction: {
+      Verbosity: 2
+      LArMCTruthProducer: "generator"
+      #LArSimEnergyDepositProducer: "largeant TPCActive"
+      LArSimEnergyDepositLiteProducer: "sedlite"
+			UseSEDLite: true
+      Origin: 0
+      Cluster3DLabels: ["mcst","pcluster","sed","masked_true2reco"]
+      Tensor3DLabels:  ["reco","pcluster_index","masked_true"]
+      BBoxSize: [614.4, 614.4, 614.4] # 2048 pixels of 0.3 mm
+      BBoxBottom: [-307.2, -307.2, -57.4] # centered on the detector center with some padding
+      VoxelSize: [0.3,0.3,0.3]
+      UseFixedBBox: true
+      CryostatList: [0,0]
+      TPCList: [0,1]
+    }
+    
+    SuperaSpacePoint: {
+      Verbosity: 2
+      SpacePointProducers: ["cluster3d"]
+      OutputLabel:        "reco"
+      DropOutput: ["hit_amp","hit_rms","hit_mult","hit_time"]
+      StoreWireInfo: true
+      RecoChargeRange: [-1000, 50000]
+    }
+    SuperaOptical: {
+		  OpFlashProducers: ["opflashtpc0xarapuca","opflashtpc1xarapuca","opflashtpc0","opflashtpc1"]
+			OpFlashOutputs: ["tpc0xa","tpc1xa","tpc0","tpc1"]
+		}
+
+  }
+}

--- a/job/supera_sbnd_mpvmpr.fcl
+++ b/job/supera_sbnd_mpvmpr.fcl
@@ -82,14 +82,14 @@ ProcessDriver: {
         OutputCluster3D: "masked_true2reco"
         TwofoldMatching: true
         UseTruePosition: true
-        HitThresholdNe: 175
-        HitWindowTicks: 5 #15
+        HitThresholdNe: 100
+        HitWindowTicks: 10
         HitPeakFinding: false
         PostAveraging: true
-        PostAveragingThreshold_cm: 0.425
+        PostAveragingThreshold_cm: 0.7
         DumpToCSV: false
         RecoChargeRange: [-1000,50000]
-				VoxelDistanceThreshold: 1. #3
+				VoxelDistanceThreshold: 2.
       }
     }
 


### PR DESCRIPTION
Modify SBND Supera space point ghost labels to optimize for eff., pur. and completeness.

See docDB [32043](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=32034) for more information on parameters. Plots are below for 10 MPVMPR events.

![event_sbnd_gap_hyperparams_10event_metric](https://github.com/user-attachments/assets/756fa6d5-0513-499c-9992-43a4951665f1)
![event_sbnd_gap_hyperparams_10event_parameter](https://github.com/user-attachments/assets/d3cbb074-e1e3-48a4-b3ba-ac77088ae9bf)
![event_sbnd_pur_eff_hyperparams_10event_metric](https://github.com/user-attachments/assets/1b543e70-f579-4bca-9a4b-046c26f00406)
![event_sbnd_pur_eff_hyperparams_10event_parameter](https://github.com/user-attachments/assets/0db9348f-cc45-42a1-a8a7-4779b2c6b33e)
