### PR TITLE
Update ghost label parameters

### DIFF
--- a/job/supera_sbnd_corsika.fcl
+++ b/job/supera_sbnd_corsika.fcl
@@ -82,14 +82,14 @@ ProcessDriver: {
         OutputCluster3D: "masked_true2reco"
         TwofoldMatching: true
         UseTruePosition: true
-        HitThresholdNe: 100
-        HitWindowTicks: 10
+        HitThresholdNe: 175 #doublets 175, triplets 100 v10_04_03
+        HitWindowTicks: 15 #doublets 15, triplets 10 v10_04_03
         HitPeakFinding: false
         PostAveraging: true
-        PostAveragingThreshold_cm: 0.7
+        PostAveragingThreshold_cm: 0.7 # doublets 0.7, triplets 0.7 v10_04_03
         DumpToCSV: false
         RecoChargeRange: [-1000,50000]
-				VoxelDistanceThreshold: 2.
+				VoxelDistanceThreshold: 3. #2. triplets, 3. doublets v10_04_03
       }
     }
 

--- a/job/supera_sbnd_mpvmpr.fcl
+++ b/job/supera_sbnd_mpvmpr.fcl
@@ -82,14 +82,14 @@ ProcessDriver: {
         OutputCluster3D: "masked_true2reco"
         TwofoldMatching: true
         UseTruePosition: true
-        HitThresholdNe: 100
-        HitWindowTicks: 10
+        HitThresholdNe: 175 #doublets 175, triplets 100 v10_04_03
+        HitWindowTicks: 15 #doublets 15, triplets 10 v10_04_03
         HitPeakFinding: false
         PostAveraging: true
-        PostAveragingThreshold_cm: 0.7
+        PostAveragingThreshold_cm: 0.7 # doublets 0.7, triplets 0.7 v10_04_03
         DumpToCSV: false
         RecoChargeRange: [-1000,50000]
-				VoxelDistanceThreshold: 2.
+				VoxelDistanceThreshold: 3. #2. triplets, 3. doublets v10_04_03
       }
     }
 


### PR DESCRIPTION
Modify SBND Supera space point ghost labels to optimize for eff., pur. and completeness.

See docDB [32043](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=32034) for more information on parameters. Plots are below for 10 MPVMPR events. Doublets are used in these plots, triplets are used in PR #53.

![event_sbnd_pur_eff_hyperparams_10event_metric](https://github.com/user-attachments/assets/a9e71d83-0a58-4aa8-af18-e984fbae0863)
![event_sbnd_pur_eff_hyperparams_10event_parameter](https://github.com/user-attachments/assets/f5a1fac5-0774-4883-8c83-cc3d00eb5a07)
![event_sbnd_gap_hyperparams_10event_metric](https://github.com/user-attachments/assets/1931f96c-88d4-44c9-b068-198342d851a9)
![event_sbnd_gap_hyperparams_10event_parameter](https://github.com/user-attachments/assets/18bfd5f4-7991-41ac-9347-acb78f71735e)
