### PR TITLE
Store MCParticles of Nuclei

### DIFF
--- a/SuperaMCParticleCluster.cxx
+++ b/SuperaMCParticleCluster.cxx
@@ -170,7 +170,7 @@ namespace larcv {
 
   std::map<int, supera::ParticleGroup> SuperaMCParticleCluster::CreateParticleGroups()
   {
-    LARCV_DEBUG() << "****---- CreateParticleGroups" << std::endl;
+    LARCV_DEBUG() << "****---- CreateParticleGroups DOING THIS" << std::endl;
     const larcv::Particle invalid_part;
     auto const& larmcp_v = LArData<supera::LArMCParticle_t>();
     auto const& parent_pdg_v = _mcpl.ParentPdgCode();
@@ -187,7 +187,10 @@ namespace larcv {
         mother_index = trackid2index[mcpart.Mother()];
 
       //if(pdg_code != -11 && pdg_code != 11 && pdg_code != 22) continue;
-      if (pdg_code > 1000000) continue;
+      // if (pdg_code > 1000000){
+      //   LARCV_DEBUG() << "Skipping PDG code " << pdg_code << " track id " << track_id << std::endl;
+      //   continue;
+      // }
 
       supera::ParticleGroup grp(_valid_nplanes);
       LARCV_DEBUG() << "grp.part make particle" << std::endl;
@@ -229,6 +232,7 @@ namespace larcv {
       else {
         grp.type = supera::kTrack;
         if (grp.part.pdg_code() == 2112) grp.type = supera::kNeutron;
+        if (grp.part.pdg_code() > 1000000) grp.type = supera::kNuclear;
         result[track_id] = grp;
       }
       LARCV_DEBUG() << "***--- first_step in for loop " << grp.part.first_step().x() << "Track ID "
@@ -656,6 +660,10 @@ namespace larcv {
                         << " Recorded: " << recorded_xrange2d.first << " => "
                         << recorded_xrange2d.second << " ... T range: " << recorded_trange2d.first
                         << " => " << recorded_trange2d.second << std::endl;
+      }
+      LARCV_DEBUG() << "Missing track IDs: " << std::endl;
+      for (auto const& tid : missing_trackid) {
+        LARCV_DEBUG() << " " << tid << std::endl;
       }
     }
   }

--- a/SuperaMCParticleCluster.cxx
+++ b/SuperaMCParticleCluster.cxx
@@ -168,77 +168,108 @@ namespace larcv {
     return _scan[cryo_id][tpc_id][plane_id];
   }
 
+  void SuperaMCParticleCluster::SetParticleGroupType(supera::ParticleGroup& grp, const supera::LArMCParticle_t& mcpart, const larcv::Particle& invalid_part) const
+  {
+      int pdg_code = abs(mcpart.PdgCode());
+      if (pdg_code == 22 || pdg_code == 11) {
+          if (pdg_code == 22) {
+              grp.type = supera::kPhoton;
+              grp.part.first_step(invalid_part.first_step());
+              grp.part.last_step(invalid_part.last_step());
+              grp.part.end_position(invalid_part.end_position());
+          } else if (pdg_code == 11) {
+              std::string prc = mcpart.Process();
+              if (prc == "muIoni" || prc == "hIoni" || prc == "muPairProd")
+                  grp.type = supera::kDelta;
+              else if (prc == "muMinusCaptureAtRest" || prc == "muPlusCaptureAtRest" || prc == "Decay")
+                  grp.type = supera::kDecay;
+              else if (prc == "compt")
+                  grp.type = supera::kCompton;
+              else if (prc == "phot")
+                  grp.type = supera::kPhotoElectron;
+              else if (prc == "eIoni")
+                  grp.type = supera::kIonization;
+              else if (prc == "conv")
+                  grp.type = supera::kConversion;
+              else if (prc == "primary")
+                  grp.type = supera::kPrimary;
+              else
+                  grp.type = supera::kOtherShower;
+          }
+      } else {
+          grp.type = supera::kTrack;
+          if (grp.part.pdg_code() == 2112) grp.type = supera::kNeutron;
+          if (grp.part.pdg_code() > 1000000) grp.type = supera::kNuclear;
+      }
+  }
+
   std::map<int, supera::ParticleGroup> SuperaMCParticleCluster::CreateParticleGroups()
   {
-    LARCV_DEBUG() << "****---- CreateParticleGroups" << std::endl;
-    const larcv::Particle invalid_part;
-    auto const& larmcp_v = LArData<supera::LArMCParticle_t>();
-    auto const& parent_pdg_v = _mcpl.ParentPdgCode();
-    auto const& trackid2index = _mcpl.TrackIdToIndex();
-    std::map<int, supera::ParticleGroup> result;
-    //result.reserve(larmcp_v.size());
-    for (size_t index = 0; index < larmcp_v.size(); ++index) {
+      LARCV_DEBUG() << "****---- CreateParticleGroups" << std::endl;
+      const larcv::Particle invalid_part;
+      auto const& larmcp_v = LArData<supera::LArMCParticle_t>();
+      auto const& parent_pdg_v = _mcpl.ParentPdgCode();
+      auto const& trackid2index = _mcpl.TrackIdToIndex();
+      std::map<int, supera::ParticleGroup> result;
 
-      auto const& mcpart = larmcp_v[index];
-      int pdg_code = abs(mcpart.PdgCode());
-      int mother_index = -1;
-      int track_id = mcpart.TrackId();
-      if (mcpart.Mother() < ((int)(trackid2index.size())))
-        mother_index = trackid2index[mcpart.Mother()];
+      // First pass: create particle groups for relevant particles
+      for (size_t index = 0; index < larmcp_v.size(); ++index) {
+          auto const& mcpart = larmcp_v[index];
+          int pdg_code = abs(mcpart.PdgCode());
+          int mother_index = -1;
+          int track_id = mcpart.TrackId();
+          if (mcpart.Mother() < ((int)(trackid2index.size())))
+              mother_index = trackid2index[mcpart.Mother()];
 
-      supera::ParticleGroup grp(_valid_nplanes);
-      LARCV_DEBUG() << "grp.part make particle" << std::endl;
-      grp.part = this->MakeParticle(mcpart);
+          if (pdg_code > 1000000) {
+              // Skip nucleus with no daughters
+              LARCV_DEBUG() << "Skipping nucleus " << pdg_code << " track id "
+                            << track_id << std::endl;
+              continue;
+          }
 
-      if (mother_index >= 0) grp.part.parent_pdg_code(parent_pdg_v[index]);
-      grp.valid = true;
+          supera::ParticleGroup grp(_valid_nplanes);
+          LARCV_DEBUG() << "grp.part make particle" << std::endl;
+          grp.part = this->MakeParticle(mcpart);
 
-      if (pdg_code == 22 || pdg_code == 11) {
-        if (pdg_code == 22) {
-          // photon ... reset first, last, and end position
-          grp.type = supera::kPhoton;
-          grp.part.first_step(invalid_part.first_step());
-          grp.part.last_step(invalid_part.last_step());
-          grp.part.end_position(invalid_part.end_position());
-        }
-        else if (pdg_code == 11) {
+          if (mother_index >= 0) grp.part.parent_pdg_code(parent_pdg_v[index]);
+          grp.valid = true;
 
-          std::string prc = mcpart.Process();
-          if (prc == "muIoni" || prc == "hIoni" || prc == "muPairProd")
-            grp.type = supera::kDelta;
-          else if (prc == "muMinusCaptureAtRest" || prc == "muPlusCaptureAtRest" || prc == "Decay")
-            grp.type = supera::kDecay;
-          else if (prc == "compt")
-            grp.type = supera::kCompton;
-          else if (prc == "phot")
-            grp.type = supera::kPhotoElectron;
-          else if (prc == "eIoni")
-            grp.type = supera::kIonization;
-          else if (prc == "conv")
-            grp.type = supera::kConversion;
-          else if (prc == "primary")
-            grp.type = supera::kPrimary;
-          else
-            grp.type = supera::kOtherShower;
-        }
-        result[track_id] = grp;
+          // Use the helper function to set the type
+          SetParticleGroupType(grp, mcpart, invalid_part);
+
+          result[track_id] = grp;
+          LARCV_DEBUG() << "***--- first_step in for loop " << grp.part.first_step().x() << "Track ID "
+                        << grp.part.track_id() << " PDG " << grp.part.pdg_code() << " "
+                        << grp.part.creation_process() << " ... parent Track ID "
+                        << grp.part.parent_track_id() << " PDG " << grp.part.parent_pdg_code()
+                        << std::endl;
       }
-      else {
-        grp.type = supera::kTrack;
-        if (grp.part.pdg_code() == 2112) grp.type = supera::kNeutron;
-        if (grp.part.pdg_code() > 1000000) grp.type = supera::kNuclear;
-        result[track_id] = grp;
+      if (_assert_parent_trackid) {
+        // Second pass: check for missing parent particles
+        for (auto const& [track_id, grp] : result) {
+          int parent_track_id = grp.part.parent_track_id();
+          if (parent_track_id != static_cast<int>(larcv::kINVALID_UINT) && result.find(parent_track_id) == result.end()) {
+              // Parent is missing, add it to the result
+              if (parent_track_id < static_cast<int>(trackid2index.size())) {
+                  int parent_index = trackid2index[parent_track_id];
+                  if (parent_index >= 0 && parent_index < static_cast<int>(larmcp_v.size())) {
+                      auto const& parent_mcpart = larmcp_v[parent_index];
+                      supera::ParticleGroup parent_grp(_valid_nplanes);
+                      parent_grp.part = this->MakeParticle(parent_mcpart);
+                      parent_grp.valid = true;
+
+                      // Use the helper function to set the type
+                      SetParticleGroupType(parent_grp, parent_mcpart, invalid_part);
+
+                      result[parent_track_id] = parent_grp;
+                      LARCV_DEBUG() << "Added missing parent track ID " << parent_track_id << std::endl;
+                  }
+              }
+          }
+        }
       }
-      LARCV_DEBUG() << "***--- first_step in for loop " << grp.part.first_step().x() << "Track ID "
-                    << grp.part.track_id() << " PDG " << grp.part.pdg_code() << " "
-                    << grp.part.creation_process() << " ... parent Track ID "
-                    << grp.part.parent_track_id() << " PDG " << grp.part.parent_pdg_code()
-                    << std::endl;
-    }
-
-    // fill parentage information
-
-    return result;
+      return result;
   }
 
   template <typename sed_type>

--- a/SuperaMCParticleCluster.cxx
+++ b/SuperaMCParticleCluster.cxx
@@ -170,7 +170,7 @@ namespace larcv {
 
   std::map<int, supera::ParticleGroup> SuperaMCParticleCluster::CreateParticleGroups()
   {
-    LARCV_DEBUG() << "****---- CreateParticleGroups DOING THIS" << std::endl;
+    LARCV_DEBUG() << "****---- CreateParticleGroups" << std::endl;
     const larcv::Particle invalid_part;
     auto const& larmcp_v = LArData<supera::LArMCParticle_t>();
     auto const& parent_pdg_v = _mcpl.ParentPdgCode();
@@ -185,12 +185,6 @@ namespace larcv {
       int track_id = mcpart.TrackId();
       if (mcpart.Mother() < ((int)(trackid2index.size())))
         mother_index = trackid2index[mcpart.Mother()];
-
-      //if(pdg_code != -11 && pdg_code != 11 && pdg_code != 22) continue;
-      // if (pdg_code > 1000000){
-      //   LARCV_DEBUG() << "Skipping PDG code " << pdg_code << " track id " << track_id << std::endl;
-      //   continue;
-      // }
 
       supera::ParticleGroup grp(_valid_nplanes);
       LARCV_DEBUG() << "grp.part make particle" << std::endl;

--- a/SuperaMCParticleCluster.h
+++ b/SuperaMCParticleCluster.h
@@ -54,6 +54,7 @@ namespace larcv {
 
     //std::map<int, supera::ParticleGroup> CreateParticleGroups();
     std::map<int, supera::ParticleGroup> CreateParticleGroups();
+    void SetParticleGroupType(supera::ParticleGroup& grp, const supera::LArMCParticle_t& mcpart, const larcv::Particle& invalid_part) const;
 
     template <typename sed_type>
     void AnalyzeSimEnergyDeposit(const larcv::Voxel3DMeta& meta,

--- a/SuperaMCParticleClusterData.h
+++ b/SuperaMCParticleClusterData.h
@@ -20,6 +20,7 @@ namespace supera {
     kDecay,         // attach high E
     kOtherShower,   // anything else (low E)
     kOtherShowerHE, // anything else (high E)
+    kNuclear,       // Nucleus particle
     kInvalidProcess
   };
 

--- a/SuperaTrue2RecoVoxel3D.cxx
+++ b/SuperaTrue2RecoVoxel3D.cxx
@@ -152,10 +152,10 @@ namespace larcv {
     _voxel_size_factor = cfg.get<double>("VoxelSizeFactor", 1.);
     _voxel_distance_threshold = cfg.get<double>("VoxelDistanceThreshold", -1.);
 
-    std::cout << "HitThresholdNe: " << _hit_threshold_ne << std::endl;
-    std::cout << "HitWindowTicks: " << _hit_window_ticks << std::endl;
-    std::cout << "PostAveragingThreshold_cm: " << _post_averaging_threshold << std::endl;
-    std::cout << "VoxelDistanceThreshold: " << _voxel_distance_threshold << std::endl;
+    LARCV_INFO() << "HitThresholdNe: " << _hit_threshold_ne << std::endl;
+    LARCV_INFO() << "HitWindowTicks: " << _hit_window_ticks << std::endl;
+    LARCV_INFO() << "PostAveragingThreshold_cm: " << _post_averaging_threshold << std::endl;
+    LARCV_INFO() << "VoxelDistanceThreshold: " << _voxel_distance_threshold << std::endl;
   }
 
   void SuperaTrue2RecoVoxel3D::initialize()

--- a/SuperaTrue2RecoVoxel3D.cxx
+++ b/SuperaTrue2RecoVoxel3D.cxx
@@ -151,6 +151,11 @@ namespace larcv {
     assert(_reco_charge_range.size() == 2);
     _voxel_size_factor = cfg.get<double>("VoxelSizeFactor", 1.);
     _voxel_distance_threshold = cfg.get<double>("VoxelDistanceThreshold", -1.);
+
+    std::cout << "HitThresholdNe: " << _hit_threshold_ne << std::endl;
+    std::cout << "HitWindowTicks: " << _hit_window_ticks << std::endl;
+    std::cout << "PostAveragingThreshold_cm: " << _post_averaging_threshold << std::endl;
+    std::cout << "VoxelDistanceThreshold: " << _voxel_distance_threshold << std::endl;
   }
 
   void SuperaTrue2RecoVoxel3D::initialize()


### PR DESCRIPTION
I've found that some nuclei create daughter particles. When this happens and the parent nucleus is not stored, the daughter particle cannot find it's parent in `ParentTrackIDs` function, and throws a `map::at` error since the track ID does not exist in the map. The solution is to store nuclear particles when they are the parent of a particle that makes it into the `part_grp_v` map.